### PR TITLE
Expand playbook visualization with full Ansible syntax and view modes

### DIFF
--- a/a-station-react-app/src/components/Canvas/Canvas.tsx
+++ b/a-station-react-app/src/components/Canvas/Canvas.tsx
@@ -14,11 +14,11 @@ import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useJobStore } from "@/stores/jobStore";
 import { nodeTypes } from "@/components/Canvas/nodeTypes";
 import { Button } from "@/components/ui";
-import { Play } from "lucide-react";
+import { Play, List, Columns } from "lucide-react";
 import { useJobExecution } from "@/hooks";
 import type { FileTreeNode } from "@/types";
+import type { ViewMode } from "@/types/nodes";
 
-/** Recursively collect inventory file paths from the file tree */
 function collectInventoryPaths(
   node: FileTreeNode,
   currentPath: string,
@@ -52,6 +52,11 @@ function collectInventoryPaths(
   return paths;
 }
 
+const VIEW_MODE_OPTIONS: { value: ViewMode; label: string; icon: typeof List }[] = [
+  { value: "flat", label: "Flat", icon: List },
+  { value: "grouped", label: "Grouped", icon: Columns },
+];
+
 export const Canvas = () => {
   const { executeJob } = useJobExecution();
   const { setCurrentJob } = useJobStore();
@@ -63,6 +68,8 @@ export const Canvas = () => {
     onConnect,
     loadFromYAML,
     clearCanvas,
+    viewMode,
+    setViewMode,
   } = useCanvasStore();
   const {
     selectedFilePath,
@@ -74,7 +81,7 @@ export const Canvas = () => {
 
   const [inventoryPath, setInventoryPath] = useState<string>("");
 
-  // Load YAML into canvas when selected file changes
+  // Reload canvas when view mode changes
   useEffect(() => {
     if (
       selectedFileContent &&
@@ -83,9 +90,8 @@ export const Canvas = () => {
     ) {
       loadFromYAML(selectedFileContent, selectedFilePath, activeSourceId || "default");
     }
-  }, [selectedFilePath, selectedFileContent, loadFromYAML, activeSourceId]);
+  }, [selectedFilePath, selectedFileContent, loadFromYAML, activeSourceId, viewMode]);
 
-  // Derive inventory paths from file tree
   const inventoryPaths = useMemo(() => {
     if (!fileTree?.children) return [];
     const paths: string[] = [];
@@ -95,7 +101,6 @@ export const Canvas = () => {
     return paths;
   }, [fileTree]);
 
-  // Auto-select first inventory if none selected
   useEffect(() => {
     if (!inventoryPath && inventoryPaths.length > 0) {
       setInventoryPath(inventoryPaths[0]);
@@ -103,6 +108,19 @@ export const Canvas = () => {
   }, [inventoryPaths, inventoryPath]);
 
   const proOptions = { hideAttribution: true };
+
+  // Count meaningful nodes (tasks + roles)
+  const nodeStats = useMemo(() => {
+    let tasks = 0;
+    let roles = 0;
+    let plays = 0;
+    for (const n of nodes) {
+      if (n.data.type === "simpleTask") tasks++;
+      else if (n.data.type === "roleNode") roles++;
+      else if (n.data.type === "headNode") plays++;
+    }
+    return { tasks, roles, plays };
+  }, [nodes]);
 
   return (
     <div className="flex-1 h-full bg-muted/70 overflow-auto relative">
@@ -131,24 +149,57 @@ export const Canvas = () => {
               case "skipped":
                 return "#eab308";
               default:
+                if (node.data.type === "taskGroup") return "#64748b";
+                if (node.data.type === "roleNode") return "#10b981";
                 return "#94a3b8";
             }
           }}
         />
+
+        {/* Top-left: Clear + View Toggle */}
         <Panel position="top-left" className="flex items-center gap-2">
           <Button variant="canvas" onClick={clearCanvas}>
             Clear Canvas
           </Button>
+
+          <div className="flex items-center bg-background/90 backdrop-blur rounded-lg border overflow-hidden">
+            {VIEW_MODE_OPTIONS.map((opt) => {
+              const Icon = opt.icon;
+              return (
+                <button
+                  key={opt.value}
+                  onClick={() => setViewMode(opt.value)}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors ${
+                    viewMode === opt.value
+                      ? "bg-primary text-primary-foreground"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  <Icon className="w-3.5 h-3.5" />
+                  {opt.label}
+                </button>
+              );
+            })}
+          </div>
         </Panel>
 
+        {/* Top-right: File info + Execute */}
         {selectedFilePath && nodes.length > 0 && (
           <Panel position="top-right" className="min-w-38">
             <div className="bg-background/90 backdrop-blur px-3 py-2 rounded-lg border text-sm space-y-2">
               <div className="flex justify-between items-center gap-3">
                 <div>
                   <div className="font-semibold">{selectedFilePath}</div>
-                  <div className="text-xs text-muted-foreground mt-1">
-                    {nodes.length} tasks
+                  <div className="text-xs text-muted-foreground mt-1 flex gap-2">
+                    {nodeStats.plays > 0 && (
+                      <span>{nodeStats.plays} plays</span>
+                    )}
+                    {nodeStats.tasks > 0 && (
+                      <span>{nodeStats.tasks} tasks</span>
+                    )}
+                    {nodeStats.roles > 0 && (
+                      <span>{nodeStats.roles} roles</span>
+                    )}
                   </div>
                 </div>
 
@@ -179,7 +230,6 @@ export const Canvas = () => {
                 </Button>
               </div>
 
-              {/* Inventory picker */}
               {inventoryPaths.length > 0 ? (
                 <select
                   value={inventoryPath}

--- a/a-station-react-app/src/components/Canvas/HeadNode.tsx
+++ b/a-station-react-app/src/components/Canvas/HeadNode.tsx
@@ -159,12 +159,15 @@ export const HeadNode = ({ id, data, selected }: HeadNodeProps) => {
 
       {/* Collapsed Summary */}
       {!data.isExpanded && (
-        <div className="px-4 py-2 text-xs text-muted-foreground">
+        <div className="px-4 py-2 text-xs text-muted-foreground space-y-0.5">
           {data.hosts && (
-            <span>
+            <div>
               Hosts:{" "}
               {Array.isArray(data.hosts) ? data.hosts.join(", ") : data.hosts}
-            </span>
+            </div>
+          )}
+          {data.taskGroupSummary && (
+            <div>{data.taskGroupSummary}</div>
           )}
         </div>
       )}

--- a/a-station-react-app/src/components/Canvas/RoleNode.tsx
+++ b/a-station-react-app/src/components/Canvas/RoleNode.tsx
@@ -1,0 +1,100 @@
+import { Handle, Position } from "@xyflow/react";
+import type { NodeProps } from "@xyflow/react";
+import type { RoleNodeData } from "@/types/nodes";
+import { cn } from "@/lib/utils";
+import {
+  Blocks,
+  Check,
+  CircleX,
+  RefreshCcw,
+  SkipForward,
+} from "lucide-react";
+
+export const RoleNode = ({ data, selected }: NodeProps<RoleNodeData>) => {
+  const getStateStyles = () => {
+    switch (data.state) {
+      case "running":
+        return "border-blue-500 bg-blue-50 dark:bg-blue-950/40 shadow-lg shadow-blue-200 dark:shadow-blue-900/30 animate-pulse";
+      case "success":
+        return "border-green-500 bg-green-50 dark:bg-green-950/40";
+      case "failed":
+        return "border-red-500 bg-red-50 dark:bg-red-950/40";
+      case "skipped":
+        return "border-yellow-500 bg-yellow-50 dark:bg-yellow-950/40";
+      default:
+        return "border-emerald-400 dark:border-emerald-600 bg-emerald-50 dark:bg-emerald-950/30";
+    }
+  };
+
+  const getStateIcon = () => {
+    switch (data.state) {
+      case "running":
+        return <RefreshCcw className="w-3.5 h-3.5 text-blue-500 animate-spin" />;
+      case "success":
+        return <Check className="w-3.5 h-3.5 text-green-500" />;
+      case "failed":
+        return <CircleX className="w-3.5 h-3.5 text-red-500" />;
+      case "skipped":
+        return <SkipForward className="w-3.5 h-3.5 text-yellow-500" />;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        "px-4 py-3 rounded-lg border-2 min-w-[200px] transition-all duration-200",
+        getStateStyles(),
+        selected && "ring-2 ring-primary ring-offset-2",
+      )}
+    >
+      <Handle
+        type="target"
+        position={Position.Top}
+        className="!bg-emerald-500 !w-3 !h-3"
+      />
+
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1.5 mb-1">
+            <Blocks className="w-3.5 h-3.5 text-emerald-600 dark:text-emerald-400 flex-shrink-0" />
+            <span className="text-[10px] font-bold uppercase tracking-wider text-emerald-600 dark:text-emerald-400">
+              Role
+            </span>
+          </div>
+          <div className="font-semibold text-sm text-foreground truncate">
+            {data.name}
+          </div>
+
+          {data.tags && data.tags.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-1.5">
+              {data.tags.map((tag, i) => (
+                <span
+                  key={i}
+                  className="px-1.5 py-0.5 bg-emerald-200/60 dark:bg-emerald-800/40 text-emerald-700 dark:text-emerald-300 rounded text-[10px]"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {data.when && (
+            <div className="text-[10px] text-muted-foreground mt-1 font-mono truncate">
+              when: {data.when}
+            </div>
+          )}
+        </div>
+
+        <div className="flex-shrink-0">{getStateIcon()}</div>
+      </div>
+
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!bg-emerald-500 !w-3 !h-3"
+      />
+    </div>
+  );
+};

--- a/a-station-react-app/src/components/Canvas/SimpleTaskNode.tsx
+++ b/a-station-react-app/src/components/Canvas/SimpleTaskNode.tsx
@@ -2,56 +2,53 @@ import { Handle, Position } from "@xyflow/react";
 import type { NodeProps } from "@xyflow/react";
 import type { TaskNodeData } from "@/types/nodes";
 import { cn } from "@/lib/utils";
-import { Check, CircleX, RefreshCcw, SkipForward } from "lucide-react";
+import { Check, CircleX, RefreshCcw, SkipForward, Shield, RotateCcw } from "lucide-react";
+
+const GROUP_BADGE_STYLES: Record<string, string> = {
+  pre_tasks: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
+  tasks: "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300",
+  post_tasks: "bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300",
+  handlers: "bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300",
+};
+
+const BLOCK_ICONS: Record<string, { icon: typeof Shield; color: string }> = {
+  rescue: { icon: Shield, color: "text-orange-500" },
+  always: { icon: RotateCcw, color: "text-cyan-500" },
+};
 
 export const SimpleTaskNode = ({ data, selected }: NodeProps<TaskNodeData>) => {
-  // State-based styling
   const getStateStyles = () => {
     switch (data.state) {
       case "running":
-        return "border-blue-500 bg-blue-50 shadow-lg shadow-blue-200 animate-pulse";
+        return "border-blue-500 bg-blue-50 dark:bg-blue-950/40 shadow-lg shadow-blue-200 dark:shadow-blue-900/30 animate-pulse";
       case "success":
-        return "border-green-500 bg-green-50";
+        return "border-green-500 bg-green-50 dark:bg-green-950/40";
       case "failed":
-        return "border-red-500 bg-red-50";
+        return "border-red-500 bg-red-50 dark:bg-red-950/40";
       case "skipped":
-        return "border-yellow-500 bg-yellow-50";
+        return "border-yellow-500 bg-yellow-50 dark:bg-yellow-950/40";
       default:
         return "border-border bg-background";
     }
   };
 
-  // State icons
   const getStateIcon = () => {
     switch (data.state) {
       case "running":
-        return (
-          <div className="text-blue-500 text-xl animate-spin">
-            <RefreshCcw />
-          </div>
-        );
+        return <RefreshCcw className="w-4 h-4 text-blue-500 animate-spin" />;
       case "success":
-        return (
-          <div className="text-green-500 text-xl">
-            <Check />
-          </div>
-        );
+        return <Check className="w-4 h-4 text-green-500" />;
       case "failed":
-        return (
-          <div className="text-red-500 text-xl">
-            <CircleX />
-          </div>
-        );
+        return <CircleX className="w-4 h-4 text-red-500" />;
       case "skipped":
-        return (
-          <div className="text-yellow-500 text-xl">
-            <SkipForward />
-          </div>
-        );
+        return <SkipForward className="w-4 h-4 text-yellow-500" />;
       default:
         return null;
     }
   };
+
+  const badgeStyle = GROUP_BADGE_STYLES[data.taskGroup] ?? GROUP_BADGE_STYLES.tasks;
+  const blockInfo = data.blockType ? BLOCK_ICONS[data.blockType] : null;
 
   return (
     <div
@@ -61,7 +58,6 @@ export const SimpleTaskNode = ({ data, selected }: NodeProps<TaskNodeData>) => {
         selected && "ring-2 ring-primary ring-offset-2",
       )}
     >
-      {/* Input handle */}
       <Handle
         type="target"
         position={Position.Top}
@@ -70,6 +66,21 @@ export const SimpleTaskNode = ({ data, selected }: NodeProps<TaskNodeData>) => {
 
       <div className="flex items-start justify-between gap-3">
         <div className="flex-1 min-w-0">
+          {/* Group badge + block indicator */}
+          <div className="flex items-center gap-1.5 mb-1">
+            <span className={cn("px-1.5 py-0.5 rounded text-[10px] font-medium", badgeStyle)}>
+              {data.taskGroup.replace("_", "-")}
+            </span>
+            {data.roleName && (
+              <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
+                {data.roleName}
+              </span>
+            )}
+            {blockInfo && (
+              <blockInfo.icon className={cn("w-3 h-3", blockInfo.color)} />
+            )}
+          </div>
+
           <div className="font-semibold text-sm text-foreground truncate">
             {data.name}
           </div>
@@ -77,12 +88,6 @@ export const SimpleTaskNode = ({ data, selected }: NodeProps<TaskNodeData>) => {
           <div className="text-xs text-muted-foreground mt-1 flex items-center gap-1">
             <span className="font-mono">{data.module}</span>
           </div>
-
-          {data.playName && (
-            <div className="text-xs text-muted-foreground/70 mt-1 italic truncate">
-              {data.playName}
-            </div>
-          )}
         </div>
 
         <div className="flex-shrink-0">{getStateIcon()}</div>

--- a/a-station-react-app/src/components/Canvas/TaskGroupNode.tsx
+++ b/a-station-react-app/src/components/Canvas/TaskGroupNode.tsx
@@ -1,0 +1,85 @@
+import { Handle, Position } from "@xyflow/react";
+import type { NodeProps } from "@xyflow/react";
+import type { TaskGroupNodeData } from "@/types/nodes";
+import { cn } from "@/lib/utils";
+import {
+  ListChecks,
+  Blocks,
+  ClipboardList,
+  ClipboardCheck,
+  Bell,
+} from "lucide-react";
+
+const GROUP_STYLES: Record<
+  string,
+  { icon: typeof ListChecks; color: string; bg: string; border: string }
+> = {
+  pre_tasks: {
+    icon: ListChecks,
+    color: "text-blue-600 dark:text-blue-400",
+    bg: "bg-blue-50 dark:bg-blue-950/40",
+    border: "border-blue-300 dark:border-blue-700",
+  },
+  roles: {
+    icon: Blocks,
+    color: "text-emerald-600 dark:text-emerald-400",
+    bg: "bg-emerald-50 dark:bg-emerald-950/40",
+    border: "border-emerald-300 dark:border-emerald-700",
+  },
+  tasks: {
+    icon: ClipboardList,
+    color: "text-amber-600 dark:text-amber-400",
+    bg: "bg-amber-50 dark:bg-amber-950/40",
+    border: "border-amber-300 dark:border-amber-700",
+  },
+  post_tasks: {
+    icon: ClipboardCheck,
+    color: "text-purple-600 dark:text-purple-400",
+    bg: "bg-purple-50 dark:bg-purple-950/40",
+    border: "border-purple-300 dark:border-purple-700",
+  },
+  handlers: {
+    icon: Bell,
+    color: "text-rose-600 dark:text-rose-400",
+    bg: "bg-rose-50 dark:bg-rose-950/40",
+    border: "border-rose-300 dark:border-rose-700",
+  },
+};
+
+export const TaskGroupNode = ({
+  data,
+  selected,
+}: NodeProps<TaskGroupNodeData>) => {
+  const style = GROUP_STYLES[data.groupType] ?? GROUP_STYLES.tasks;
+  const Icon = style.icon;
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border-2 min-w-[220px] transition-all duration-200",
+        style.border,
+        style.bg,
+        selected && "ring-2 ring-primary ring-offset-2",
+      )}
+    >
+      <Handle
+        type="target"
+        position={Position.Top}
+        className="!bg-primary !w-3 !h-3"
+      />
+
+      <div className="px-3 py-2 flex items-center gap-2">
+        <Icon className={cn("w-4 h-4", style.color)} />
+        <span className={cn("text-xs font-bold uppercase tracking-wide", style.color)}>
+          {data.label}
+        </span>
+      </div>
+
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!bg-primary !w-3 !h-3"
+      />
+    </div>
+  );
+};

--- a/a-station-react-app/src/components/Canvas/nodeTypes.tsx
+++ b/a-station-react-app/src/components/Canvas/nodeTypes.tsx
@@ -1,7 +1,11 @@
 import { SimpleTaskNode } from "./SimpleTaskNode";
-import {HeadNode} from "@/components/Canvas/HeadNode.tsx";
+import { HeadNode } from "./HeadNode";
+import { TaskGroupNode } from "./TaskGroupNode";
+import { RoleNode } from "./RoleNode";
 
 export const nodeTypes = {
   simpleTask: SimpleTaskNode,
   headNode: HeadNode,
+  taskGroup: TaskGroupNode,
+  roleNode: RoleNode,
 };

--- a/a-station-react-app/src/components/DashboardNavigation.tsx
+++ b/a-station-react-app/src/components/DashboardNavigation.tsx
@@ -1,4 +1,4 @@
-import { GalleryVerticalEnd, ListFilterPlus, Plus } from "lucide-react";
+import { FolderTree, Server, History } from "lucide-react";
 import { Button } from "@/components/ui";
 
 export const DashboardNavigation = () => {
@@ -7,18 +7,18 @@ export const DashboardNavigation = () => {
       <div className="flex flex-col items-center">
         <Button className="flex items-center justify-center w-10 h-10 rounded-lg bg-muted hover:bg-accent transition-colors">
           <span className="text-muted-foreground text-sm">
-            <Plus />
+            <FolderTree />
           </span>
         </Button>
         <Button className="flex items-center justify-center w-10 h-10 rounded-lg bg-muted hover:bg-accent transition-colors">
           <span className="text-muted-foreground text-sm">
-            <GalleryVerticalEnd />
+            <Server />
           </span>
         </Button>
 
         <Button className="flex items-center justify-center w-10 h-10 rounded-lg bg-muted hover:bg-accent transition-colors">
           <span className="text-muted-foreground text-sm">
-            <ListFilterPlus />
+            <History />
           </span>
         </Button>
       </div>

--- a/a-station-react-app/src/components/FileTree.tsx
+++ b/a-station-react-app/src/components/FileTree.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useSourceStore } from "@/stores/sourceStore";
 import { useAuthStore } from "@/stores/authStore";
-import { useCanvasStore } from "@/stores/canvasStore";
 import { AddSource } from "@/components/Modals/AddSource";
 import { Button } from "@/components/ui";
 import {
@@ -15,6 +14,7 @@ import {
   HardDrive,
   Plus,
   RefreshCw,
+  Trash2,
 } from "lucide-react";
 import type { FileTreeNode } from "@/types";
 
@@ -110,9 +110,8 @@ export const FileTree = () => {
     setActiveSource,
     selectFile,
     syncSource,
+    removeSource,
   } = useSourceStore();
-  const { loadFromYAML } = useCanvasStore();
-
   useEffect(() => {
     if (!selectedWorkspace || !token) return;
     fetchSources(selectedWorkspace.id, token);
@@ -124,14 +123,6 @@ export const FileTree = () => {
     if (!selectedWorkspace || !token || !activeSourceId) return;
 
     await selectFile(selectedWorkspace.id, activeSourceId, path, token);
-
-    // Load YAML files into canvas
-    if (isYamlFile(path)) {
-      const content = useSourceStore.getState().selectedFileContent;
-      if (content) {
-        loadFromYAML(content, path, activeSourceId);
-      }
-    }
   };
 
   const handleSync = async () => {
@@ -147,14 +138,31 @@ export const FileTree = () => {
       <div className="px-3 py-2 border-b border-border space-y-2">
         <div className="flex items-center justify-between">
           <h2 className="text-sm font-semibold text-foreground">Source</h2>
-          <AddSource
-            workspaceId={selectedWorkspace.id}
-            trigger={
-              <Button className="flex items-center justify-center w-6 h-6 rounded bg-transparent hover:bg-accent transition-colors">
-                <Plus className="w-3.5 h-3.5 text-muted-foreground" />
+          <div className="flex items-center gap-0.5">
+            {activeSourceId && (
+              <Button
+                className="flex items-center justify-center w-6 h-6 rounded bg-transparent hover:bg-destructive/10 transition-colors"
+                onClick={() => {
+                  if (!token || !activeSourceId) return;
+                  const source = sources.find((s) => s.id === activeSourceId);
+                  if (!source) return;
+                  if (!window.confirm(`Remove source "${source.name}"?`)) return;
+                  removeSource(selectedWorkspace.id, activeSourceId, token);
+                }}
+                title="Remove source"
+              >
+                <Trash2 className="w-3.5 h-3.5 text-muted-foreground" />
               </Button>
-            }
-          />
+            )}
+            <AddSource
+              workspaceId={selectedWorkspace.id}
+              trigger={
+                <Button className="flex items-center justify-center w-6 h-6 rounded bg-transparent hover:bg-accent transition-colors">
+                  <Plus className="w-3.5 h-3.5 text-muted-foreground" />
+                </Button>
+              }
+            />
+          </div>
         </div>
 
         {sources.length > 0 && (

--- a/a-station-react-app/src/components/ToolBar/YamlCodeViewer.tsx
+++ b/a-station-react-app/src/components/ToolBar/YamlCodeViewer.tsx
@@ -25,7 +25,7 @@ export function YamlCodeViewer({
   const safeContent = typeof content === "string" ? content : "";
 
   return (
-    <div className="h-full w-full overflow-scroll mb-20">
+    <div className="h-full w-full overflow-hidden">
       <CodeMirror
         value={safeContent}
         height={height}

--- a/a-station-react-app/src/components/ToolBar/YamlTab.tsx
+++ b/a-station-react-app/src/components/ToolBar/YamlTab.tsx
@@ -9,7 +9,7 @@ export function YamlTab() {
   const content = selectedFileContent ?? "";
 
   return (
-    <div className="h-full w-full">
+    <div className="h-full w-full flex flex-col">
       <div className="flex items-center justify-between px-3 py-2 border-b border-border bg-muted/30">
         <div className="flex items-center gap-2">
           <File className="w-3 h-3 text-muted-foreground" />
@@ -22,7 +22,7 @@ export function YamlTab() {
         )}
       </div>
 
-      <div>
+      <div className="flex-1 min-h-0 overflow-hidden">
         <YamlCodeViewer content={content} readOnly height="100%" />
       </div>
     </div>

--- a/a-station-react-app/src/services/yaml-parser.ts
+++ b/a-station-react-app/src/services/yaml-parser.ts
@@ -1,12 +1,86 @@
 import yaml from "js-yaml";
-import type {PlaybookTask, ParseResult, HeadNode} from "@/types/nodes";
+import type {
+  PlaybookTask,
+  ParseResult,
+  HeadNode,
+  TaskGroupType,
+  TaskGroup,
+  PlaybookRole,
+} from "@/types/nodes";
+
+const TASK_META_KEYS = new Set([
+  "name",
+  "when",
+  "with_items",
+  "with_dict",
+  "with_fileglob",
+  "with_first_found",
+  "with_together",
+  "with_subelements",
+  "with_sequence",
+  "with_random_choice",
+  "with_nested",
+  "with_indexed_items",
+  "with_flattened",
+  "loop",
+  "loop_control",
+  "register",
+  "ignore_errors",
+  "ignore_unreachable",
+  "changed_when",
+  "failed_when",
+  "tags",
+  "become",
+  "become_user",
+  "become_method",
+  "become_flags",
+  "delegate_to",
+  "delegate_facts",
+  "notify",
+  "vars",
+  "environment",
+  "async",
+  "poll",
+  "retries",
+  "delay",
+  "until",
+  "block",
+  "rescue",
+  "always",
+  "listen",
+  "no_log",
+  "check_mode",
+  "diff",
+  "any_errors_fatal",
+  "throttle",
+  "run_once",
+  "connection",
+  "timeout",
+  "collections",
+  "module_defaults",
+  "args",
+  "debugger",
+  "action",
+  "local_action",
+]);
+
+const TASK_GROUP_DEFS: {
+  key: string;
+  type: TaskGroupType;
+  label: string;
+}[] = [
+  { key: "pre_tasks", type: "pre_tasks", label: "Pre-Tasks" },
+  { key: "roles", type: "roles", label: "Roles" },
+  { key: "tasks", type: "tasks", label: "Tasks" },
+  { key: "post_tasks", type: "post_tasks", label: "Post-Tasks" },
+  { key: "handlers", type: "handlers", label: "Handlers" },
+];
 
 export class PlaybookParser {
-  // Public method for backward compatibility (single playbook)
   public parse(
     yamlContent: string,
     playbookFile: string = "playbook.yml",
-    playbookId: string = "default"
+    playbookId: string = "default",
   ): ParseResult {
     return this.parseSingle(yamlContent, playbookFile, playbookId, 0);
   }
@@ -15,10 +89,16 @@ export class PlaybookParser {
     yamlContent: string,
     playbookFile: string,
     playbookId: string,
-    startingOrder: number
+    startingOrder: number,
   ): ParseResult {
     if (!yamlContent || yamlContent.trim() === "") {
-      return {success: true, headNodes: [], tasks: []};
+      return {
+        success: true,
+        headNodes: [],
+        tasks: [],
+        taskGroups: [],
+        roles: [],
+      };
     }
 
     try {
@@ -29,20 +109,23 @@ export class PlaybookParser {
           success: false,
           headNodes: [],
           tasks: [],
+          taskGroups: [],
+          roles: [],
           error: "Playbook must be a list of plays",
         };
       }
 
       const headNodes: HeadNode[] = [];
       const tasks: PlaybookTask[] = [];
+      const taskGroups: TaskGroup[] = [];
+      const roles: PlaybookRole[] = [];
       let globalOrder = startingOrder;
 
       for (let playIndex = 0; playIndex < parsed.length; playIndex++) {
         const play = parsed[playIndex];
-
-        // Create HeadNode for this play
         const headNodeId = `head-${playbookId}-play${playIndex}`;
-        const headNode: HeadNode = {
+
+        headNodes.push({
           id: headNodeId,
           playbookId,
           playbookFile,
@@ -54,91 +137,192 @@ export class PlaybookParser {
           vars: play.vars,
           tags: play.tags,
           gather_facts: play.gather_facts,
-        };
-
-        headNodes.push(headNode);
+        });
         globalOrder++;
 
-        // Extract tasks for this play
-        const playTasks = this.extractPlayTasks(
-          play,
-          playbookId,
-          playbookFile,
-          headNodeId,
-          play.name || "Unnamed Play",
-          globalOrder
-        );
+        // Extract each task group in Ansible execution order
+        for (const groupDef of TASK_GROUP_DEFS) {
+          if (groupDef.key === "roles") {
+            if (play.roles && Array.isArray(play.roles)) {
+              const groupId = `group-${headNodeId}-roles`;
+              taskGroups.push({
+                id: groupId,
+                type: "roles",
+                parentHeadNodeId: headNodeId,
+                label: groupDef.label,
+              });
 
-        tasks.push(...playTasks);
-        globalOrder += playTasks.length;
+              for (let i = 0; i < play.roles.length; i++) {
+                const roleDef = this.parseRoleDefinition(play.roles[i]);
+                roles.push({
+                  id: `role-${headNodeId}-${i}`,
+                  name: roleDef.name,
+                  parentHeadNodeId: headNodeId,
+                  playbookId,
+                  playbookFile,
+                  order: globalOrder,
+                  vars: roleDef.vars,
+                  tags: roleDef.tags,
+                  when: roleDef.when,
+                });
+                globalOrder++;
+              }
+            }
+            continue;
+          }
+
+          const taskList = play[groupDef.key];
+          if (!taskList || !Array.isArray(taskList)) continue;
+
+          taskGroups.push({
+            id: `group-${headNodeId}-${groupDef.type}`,
+            type: groupDef.type,
+            parentHeadNodeId: headNodeId,
+            label: groupDef.label,
+          });
+
+          const extracted = this.extractTaskList(
+            taskList,
+            groupDef.type,
+            playbookId,
+            playbookFile,
+            headNodeId,
+            play.name || "Unnamed Play",
+            globalOrder,
+          );
+          tasks.push(...extracted);
+          globalOrder += extracted.length;
+        }
       }
 
-      return {
-        success: true,
-        headNodes,
-        tasks,
-      };
+      return { success: true, headNodes, tasks, taskGroups, roles };
     } catch (error) {
       return {
         success: false,
         headNodes: [],
         tasks: [],
+        taskGroups: [],
+        roles: [],
         error: error instanceof Error ? error.message : "Failed to parse YAML",
       };
     }
   }
 
   public parseMultiple(
-    playbooks: Array<{ content: string; filename: string; id: string }>
+    playbooks: Array<{ content: string; filename: string; id: string }>,
   ): ParseResult {
-    const allHeadNodes: HeadNode[] = [];
-    const allTasks: PlaybookTask[] = [];
+    const all: ParseResult = {
+      success: true,
+      headNodes: [],
+      tasks: [],
+      taskGroups: [],
+      roles: [],
+    };
     let globalOrder = 0;
 
-    for (const playbook of playbooks) {
+    for (const pb of playbooks) {
       const result = this.parseSingle(
-        playbook.content,
-        playbook.filename,
-        playbook.id,
-        globalOrder
+        pb.content,
+        pb.filename,
+        pb.id,
+        globalOrder,
       );
+      if (!result.success) return result;
 
-      if (!result.success) {
-        return result; // Early return on error
-      }
-
-      allHeadNodes.push(...result.headNodes);
-      allTasks.push(...result.tasks);
-      globalOrder = allTasks.length; // Update global order
+      all.headNodes.push(...result.headNodes);
+      all.tasks.push(...result.tasks);
+      all.taskGroups.push(...result.taskGroups);
+      all.roles.push(...result.roles);
+      globalOrder += result.tasks.length + result.roles.length;
     }
 
-    return {
-      success: true,
-      headNodes: allHeadNodes,
-      tasks: allTasks,
-    };
+    return all;
   }
 
-  private extractPlayTasks(
-    play: any,
+  // --- Task extraction ---
+
+  private extractTaskList(
+    taskList: any[],
+    groupType: TaskGroupType,
     playbookId: string,
     playbookFile: string,
     parentHeadNodeId: string,
     playName: string,
-    startingOrder: number
+    startingOrder: number,
   ): PlaybookTask[] {
     const tasks: PlaybookTask[] = [];
     let order = startingOrder;
 
-    if (play.tasks && Array.isArray(play.tasks)) {
-      for (const task of play.tasks) {
+    for (const task of taskList) {
+      if (task.block) {
+        const blockTasks = this.extractBlock(
+          task,
+          groupType,
+          playbookId,
+          playbookFile,
+          parentHeadNodeId,
+          playName,
+          order,
+        );
+        tasks.push(...blockTasks);
+        order += blockTasks.length;
+        continue;
+      }
+
+      const extracted = this.extractTask(
+        task,
+        order,
+        playName,
+        playbookId,
+        playbookFile,
+        parentHeadNodeId,
+        groupType,
+      );
+      if (extracted) {
+        tasks.push(extracted);
+        order++;
+      }
+    }
+
+    return tasks;
+  }
+
+  private extractBlock(
+    block: any,
+    groupType: TaskGroupType,
+    playbookId: string,
+    playbookFile: string,
+    parentHeadNodeId: string,
+    playName: string,
+    startingOrder: number,
+  ): PlaybookTask[] {
+    const tasks: PlaybookTask[] = [];
+    let order = startingOrder;
+
+    const sections: Array<{
+      key: string;
+      blockType: "block" | "rescue" | "always";
+    }> = [
+      { key: "block", blockType: "block" },
+      { key: "rescue", blockType: "rescue" },
+      { key: "always", blockType: "always" },
+    ];
+
+    for (const section of sections) {
+      const list = block[section.key];
+      if (!Array.isArray(list)) continue;
+
+      for (const task of list) {
         const extracted = this.extractTask(
           task,
           order,
           playName,
           playbookId,
           playbookFile,
-          parentHeadNodeId
+          parentHeadNodeId,
+          groupType,
+          undefined,
+          section.blockType,
         );
         if (extracted) {
           tasks.push(extracted);
@@ -156,12 +340,15 @@ export class PlaybookParser {
     playName: string,
     playbookId: string,
     playbookFile: string,
-    parentHeadNodeId: string
+    parentHeadNodeId: string,
+    taskGroup: TaskGroupType,
+    roleName?: string,
+    blockType?: "block" | "rescue" | "always",
   ): PlaybookTask | null {
     try {
       const taskName = task.name || this.deriveTaskName(task);
       const module = this.extractModule(task);
-      const id = `task-${order}`;
+      const id = `task-${parentHeadNodeId}-${taskGroup}-${order}`;
 
       return {
         id,
@@ -172,50 +359,79 @@ export class PlaybookParser {
         playbookId,
         playbookFile,
         parentHeadNodeId,
+        taskGroup,
+        roleName,
+        blockType,
       };
-    } catch (error) {
-      console.warn("Failed to parse task:", error);
+    } catch {
       return null;
     }
   }
 
+  // --- Role parsing ---
+
+  private parseRoleDefinition(role: any): {
+    name: string;
+    vars?: Record<string, any>;
+    tags?: string[];
+    when?: string;
+  } {
+    if (typeof role === "string") {
+      return { name: role };
+    }
+
+    if (typeof role === "object" && role !== null) {
+      const name = role.role || role.name || "Unknown role";
+      const { role: _r, name: _n, tags, when, vars, ...inlineVars } = role;
+
+      const allVars = { ...inlineVars, ...vars };
+      const hasVars = Object.keys(allVars).length > 0;
+
+      return {
+        name,
+        vars: hasVars ? allVars : undefined,
+        tags: tags
+          ? Array.isArray(tags)
+            ? tags
+            : [tags]
+          : undefined,
+        when: when ? String(when) : undefined,
+      };
+    }
+
+    return { name: String(role) };
+  }
+
+  // --- Module detection ---
+
   private deriveTaskName(task: any): string {
+    if (task.include_tasks) return `Include: ${task.include_tasks}`;
+    if (task.import_tasks) return `Import: ${task.import_tasks}`;
+    if (task.include_role) {
+      const name =
+        typeof task.include_role === "string"
+          ? task.include_role
+          : task.include_role.name;
+      return `Include role: ${name}`;
+    }
+    if (task.import_role) {
+      const name =
+        typeof task.import_role === "string"
+          ? task.import_role
+          : task.import_role.name;
+      return `Import role: ${name}`;
+    }
+
     const module = this.extractModule(task);
-    return module ? `${module} task` : "Unnamed task";
+    return module !== "unknown" ? `${module} task` : "Unnamed task";
   }
 
   private extractModule(task: any): string {
-    // Meta keys to ignore
-    const metaKeys = [
-      "name",
-      "when",
-      "with_items",
-      "loop",
-      "register",
-      "ignore_errors",
-      "changed_when",
-      "failed_when",
-      "tags",
-      "become",
-      "become_user",
-      "delegate_to",
-      "notify",
-      "vars",
-      "environment",
-      "async",
-      "poll",
-      "retries",
-      "delay",
-      "until",
-    ];
-
-    const keys = Object.keys(task);
-    for (const key of keys) {
-      if (!metaKeys.includes(key)) {
+    for (const key of Object.keys(task)) {
+      if (!TASK_META_KEYS.has(key)) {
         return key;
       }
     }
-
     return "unknown";
   }
 }

--- a/a-station-react-app/src/stores/canvasStore.ts
+++ b/a-station-react-app/src/stores/canvasStore.ts
@@ -7,20 +7,44 @@ import {
   applyEdgeChanges,
 } from "@xyflow/react";
 import type { OnNodesChange, OnEdgesChange, OnConnect } from "@xyflow/react";
-import type { TaskNodeData, ExecutionState, HeadNodeData } from "@/types/nodes";
+import type {
+  TaskNodeData,
+  HeadNodeData,
+  TaskGroupNodeData,
+  RoleNodeData,
+  ExecutionState,
+  AnyNodeData,
+  ViewMode,
+  ParseResult,
+  TaskGroupType,
+} from "@/types/nodes";
 import { playbookParser } from "@/services/yaml-parser";
 
-interface CanvasStore {
-  // State
-  nodes: Node<TaskNodeData | HeadNodeData>[];
-  edges: Edge[];
+// Layout constants
+const HEADNODE_HEIGHT = 200;
+const TASK_HEIGHT = 100;
+const TASK_WIDTH = 260;
+const GROUP_HEADER_HEIGHT = 60;
+const COLUMN_GAP = 40;
+const PLAY_GAP = 80;
 
-  // React Flow handlers
+const GROUP_ORDER: TaskGroupType[] = [
+  "pre_tasks",
+  "roles",
+  "tasks",
+  "post_tasks",
+  "handlers",
+];
+
+interface CanvasStore {
+  nodes: Node<AnyNodeData>[];
+  edges: Edge[];
+  viewMode: ViewMode;
+
   onNodesChange: OnNodesChange;
   onEdgesChange: OnEdgesChange;
   onConnect: OnConnect;
 
-  // Playbook loading
   loadFromYAML: (
     yamlContent: string,
     playbookFile?: string,
@@ -30,10 +54,9 @@ interface CanvasStore {
     playbooks: Array<{ content: string; filename: string; id: string }>,
   ) => void;
 
-  // HeadNode management
+  setViewMode: (mode: ViewMode) => void;
   toggleHeadNodeExpansion: (headNodeId: string) => void;
 
-  // Execution state management
   updateTaskState: (taskId: string, state: ExecutionState) => void;
   updateTaskStateByName: (taskName: string, state: ExecutionState) => void;
   updateHeadNodeStateByPlayName: (
@@ -41,20 +64,305 @@ interface CanvasStore {
     state: ExecutionState,
   ) => void;
   resetAllTaskStates: () => void;
-
-  // Canvas management
   clearCanvas: () => void;
 }
+
+// ─── Layout helpers ───
+
+function buildFlatLayout(result: ParseResult): {
+  nodes: Node<AnyNodeData>[];
+  edges: Edge[];
+} {
+  const nodes: Node<AnyNodeData>[] = [];
+  const edges: Edge[] = [];
+
+  let currentX = 300;
+
+  for (const headNode of result.headNodes) {
+    let currentY = 100;
+
+    // HeadNode
+    nodes.push({
+      id: headNode.id,
+      type: "headNode",
+      position: { x: currentX, y: currentY },
+      data: {
+        ...headNode,
+        state: "idle" as ExecutionState,
+        isExpanded: false,
+        taskGroupSummary: buildGroupSummary(result, headNode.id),
+        type: "headNode" as const,
+      },
+    });
+    currentY += HEADNODE_HEIGHT;
+
+    // Tasks for this play (all groups flattened in order)
+    const playTasks = result.tasks.filter(
+      (t) => t.parentHeadNodeId === headNode.id,
+    );
+    const playRoles = result.roles.filter(
+      (r) => r.parentHeadNodeId === headNode.id,
+    );
+
+    // Interleave roles and tasks in execution order
+    const allItems: Array<{ type: "task" | "role"; order: number; data: any }> =
+      [];
+    for (const t of playTasks) {
+      allItems.push({ type: "task", order: t.order, data: t });
+    }
+    for (const r of playRoles) {
+      allItems.push({ type: "role", order: r.order, data: r });
+    }
+    allItems.sort((a, b) => a.order - b.order);
+
+    let prevId = headNode.id;
+    for (const item of allItems) {
+      if (item.type === "task") {
+        const task = item.data;
+        nodes.push({
+          id: task.id,
+          type: "simpleTask",
+          position: { x: currentX + 45, y: currentY },
+          data: {
+            taskId: task.id,
+            name: task.name,
+            module: task.module,
+            state: "idle" as ExecutionState,
+            playName: task.playName,
+            playbookFile: task.playbookFile,
+            playbookId: task.playbookId,
+            parentHeadNodeId: task.parentHeadNodeId,
+            taskGroup: task.taskGroup,
+            roleName: task.roleName,
+            blockType: task.blockType,
+            type: "simpleTask" as const,
+          },
+        });
+        edges.push({
+          id: `edge-${prevId}-${task.id}`,
+          source: prevId,
+          target: task.id,
+          type: "smoothstep",
+        });
+        prevId = task.id;
+        currentY += TASK_HEIGHT;
+      } else {
+        const role = item.data;
+        nodes.push({
+          id: role.id,
+          type: "roleNode",
+          position: { x: currentX + 45, y: currentY },
+          data: {
+            roleId: role.id,
+            name: role.name,
+            state: "idle" as ExecutionState,
+            parentHeadNodeId: role.parentHeadNodeId,
+            playbookFile: role.playbookFile,
+            playbookId: role.playbookId,
+            vars: role.vars,
+            tags: role.tags,
+            when: role.when,
+            type: "roleNode" as const,
+          },
+        });
+        edges.push({
+          id: `edge-${prevId}-${role.id}`,
+          source: prevId,
+          target: role.id,
+          type: "smoothstep",
+        });
+        prevId = role.id;
+        currentY += TASK_HEIGHT;
+      }
+    }
+
+    currentX += 500;
+  }
+
+  return { nodes, edges };
+}
+
+function buildGroupedLayout(result: ParseResult): {
+  nodes: Node<AnyNodeData>[];
+  edges: Edge[];
+} {
+  const nodes: Node<AnyNodeData>[] = [];
+  const edges: Edge[] = [];
+
+  let playStartX = 300;
+
+  for (const headNode of result.headNodes) {
+    const playGroups = result.taskGroups.filter(
+      (g) => g.parentHeadNodeId === headNode.id,
+    );
+    const playTasks = result.tasks.filter(
+      (t) => t.parentHeadNodeId === headNode.id,
+    );
+    const playRoles = result.roles.filter(
+      (r) => r.parentHeadNodeId === headNode.id,
+    );
+
+    // Calculate total columns needed for this play
+    const activeGroups = GROUP_ORDER.filter((gt) =>
+      playGroups.some((g) => g.type === gt),
+    );
+    const totalWidth =
+      activeGroups.length * (TASK_WIDTH + COLUMN_GAP) - COLUMN_GAP;
+
+    // Center the HeadNode above the columns
+    const headX = playStartX + Math.max(0, (totalWidth - 350) / 2);
+    const headY = 100;
+
+    nodes.push({
+      id: headNode.id,
+      type: "headNode",
+      position: { x: headX, y: headY },
+      data: {
+        ...headNode,
+        state: "idle" as ExecutionState,
+        isExpanded: false,
+        taskGroupSummary: buildGroupSummary(result, headNode.id),
+        type: "headNode" as const,
+      },
+    });
+
+    let colX = playStartX;
+    const groupStartY = headY + HEADNODE_HEIGHT;
+
+    for (const groupType of activeGroups) {
+      const group = playGroups.find((g) => g.type === groupType);
+      if (!group) continue;
+
+      // TaskGroup header node
+      nodes.push({
+        id: group.id,
+        type: "taskGroup",
+        position: { x: colX, y: groupStartY },
+        data: {
+          groupId: group.id,
+          groupType: group.type,
+          label: group.label,
+          parentHeadNodeId: headNode.id,
+          state: "idle" as ExecutionState,
+          type: "taskGroup" as const,
+        },
+      });
+
+      // Edge from HeadNode to group header
+      edges.push({
+        id: `edge-${headNode.id}-${group.id}`,
+        source: headNode.id,
+        target: group.id,
+        type: "smoothstep",
+      });
+
+      let itemY = groupStartY + GROUP_HEADER_HEIGHT;
+      let prevItemId = group.id;
+
+      if (groupType === "roles") {
+        // Render role nodes in this column
+        for (const role of playRoles) {
+          nodes.push({
+            id: role.id,
+            type: "roleNode",
+            position: { x: colX, y: itemY },
+            data: {
+              roleId: role.id,
+              name: role.name,
+              state: "idle" as ExecutionState,
+              parentHeadNodeId: role.parentHeadNodeId,
+              playbookFile: role.playbookFile,
+              playbookId: role.playbookId,
+              vars: role.vars,
+              tags: role.tags,
+              when: role.when,
+              type: "roleNode" as const,
+            },
+          });
+          edges.push({
+            id: `edge-${prevItemId}-${role.id}`,
+            source: prevItemId,
+            target: role.id,
+            type: "smoothstep",
+          });
+          prevItemId = role.id;
+          itemY += TASK_HEIGHT;
+        }
+      } else {
+        // Render task nodes in this column
+        const groupTasks = playTasks.filter(
+          (t) => t.taskGroup === groupType,
+        );
+        for (const task of groupTasks) {
+          nodes.push({
+            id: task.id,
+            type: "simpleTask",
+            position: { x: colX, y: itemY },
+            data: {
+              taskId: task.id,
+              name: task.name,
+              module: task.module,
+              state: "idle" as ExecutionState,
+              playName: task.playName,
+              playbookFile: task.playbookFile,
+              playbookId: task.playbookId,
+              parentHeadNodeId: task.parentHeadNodeId,
+              taskGroup: task.taskGroup,
+              roleName: task.roleName,
+              blockType: task.blockType,
+              type: "simpleTask" as const,
+            },
+          });
+          edges.push({
+            id: `edge-${prevItemId}-${task.id}`,
+            source: prevItemId,
+            target: task.id,
+            type: "smoothstep",
+          });
+          prevItemId = task.id;
+          itemY += TASK_HEIGHT;
+        }
+      }
+
+      colX += TASK_WIDTH + COLUMN_GAP;
+    }
+
+    playStartX += totalWidth + PLAY_GAP + 100;
+  }
+
+  return { nodes, edges };
+}
+
+function buildGroupSummary(result: ParseResult, headNodeId: string): string {
+  const groups = result.taskGroups.filter(
+    (g) => g.parentHeadNodeId === headNodeId,
+  );
+  const tasks = result.tasks.filter(
+    (t) => t.parentHeadNodeId === headNodeId,
+  );
+  const roles = result.roles.filter(
+    (r) => r.parentHeadNodeId === headNodeId,
+  );
+
+  const parts: string[] = [];
+  if (tasks.length > 0) parts.push(`${tasks.length} tasks`);
+  if (roles.length > 0) parts.push(`${roles.length} roles`);
+  if (groups.length > 0) parts.push(`${groups.length} groups`);
+  return parts.join(", ");
+}
+
+// ─── Store ───
 
 export const useCanvasStore = create<CanvasStore>()(
   persist(
     (set, get) => ({
       nodes: [],
       edges: [],
+      viewMode: "flat" as ViewMode,
 
       onNodesChange: (changes) => {
         set({
-          nodes: applyNodeChanges(changes, get().nodes) as Node<TaskNodeData>[],
+          nodes: applyNodeChanges(changes, get().nodes) as Node<AnyNodeData>[],
         });
       },
 
@@ -68,6 +376,10 @@ export const useCanvasStore = create<CanvasStore>()(
         set({
           edges: [...get().edges, { ...connection, id: `edge-${Date.now()}` }],
         });
+      },
+
+      setViewMode: (mode) => {
+        set({ viewMode: mode });
       },
 
       loadFromYAML: (
@@ -87,45 +399,12 @@ export const useCanvasStore = create<CanvasStore>()(
           return;
         }
 
-        if (result.headNodes && result.headNodes.length > 0) {
-          get().loadMultiplePlaybooks([
-            { content: yamlContent, filename: playbookFile, id: playbookId },
-          ]);
-          return;
-        }
+        const layout =
+          get().viewMode === "grouped"
+            ? buildGroupedLayout(result)
+            : buildFlatLayout(result);
 
-        const nodes: Node<TaskNodeData>[] = result.tasks.map((task, index) => ({
-          id: task.id,
-          type: "simpleTask",
-          position: {
-            x: 300,
-            y: 100 + index * 120,
-          },
-          data: {
-            taskId: task.id,
-            name: task.name,
-            module: task.module,
-            state: "idle",
-            playName: task.playName || "",
-            playbookFile: task.playbookFile,
-            playbookId: task.playbookId,
-            parentHeadNodeId: task.parentHeadNodeId,
-            type: "simpleTask",
-          },
-        }));
-
-        const edges: Edge[] = [];
-        for (let i = 0; i < result.tasks.length - 1; i++) {
-          edges.push({
-            id: `edge-${i}`,
-            source: result.tasks[i].id,
-            target: result.tasks[i + 1].id,
-            type: "smoothstep",
-            animated: false,
-          });
-        }
-
-        set({ nodes, edges });
+        set(layout);
       },
 
       loadMultiplePlaybooks: (playbooks) => {
@@ -137,105 +416,12 @@ export const useCanvasStore = create<CanvasStore>()(
           return;
         }
 
-        const nodes: Node<TaskNodeData | HeadNodeData>[] = [];
-        const edges: Edge[] = [];
+        const layout =
+          get().viewMode === "grouped"
+            ? buildGroupedLayout(result)
+            : buildFlatLayout(result);
 
-        let currentY = 100;
-        const HEADNODE_HEIGHT = 200; // Height when collapsed
-        const TASK_HEIGHT = 120;
-        let X_POSITION = 300;
-
-        for (const headNode of result.headNodes) {
-          nodes.push({
-            id: headNode.id,
-            type: "headNode",
-            position: { x: X_POSITION, y: currentY },
-            data: {
-              ...headNode,
-              state: "idle" as ExecutionState,
-              isExpanded: false,
-              type: "headNode" as const,
-            },
-          });
-
-          currentY += HEADNODE_HEIGHT;
-
-          const headNodeTasks = result.tasks.filter(
-            (task) => task.parentHeadNodeId === headNode.id,
-          );
-
-          for (const task of headNodeTasks) {
-            nodes.push({
-              id: task.id,
-              type: "simpleTask",
-              position: { x: X_POSITION + 50, y: currentY },
-              data: {
-                taskId: task.id,
-                name: task.name,
-                module: task.module,
-                state: "idle",
-                playName: task.playName,
-                playbookFile: task.playbookFile,
-                playbookId: task.playbookId,
-                parentHeadNodeId: task.parentHeadNodeId,
-                type: "simpleTask" as const,
-              },
-            });
-
-            currentY += TASK_HEIGHT;
-          }
-          currentY = 100;
-          X_POSITION += 500;
-        }
-
-        // Create Head edges
-        for (const headNode of result.headNodes) {
-          const headNodeTasks = result.tasks.filter(
-            (task) => task.parentHeadNodeId === headNode.id,
-          );
-
-          if (headNodeTasks.length > 0) {
-            edges.push({
-              id: `edge-${headNode.id}-to-first-task`,
-              source: headNode.id,
-              target: headNodeTasks[0].id,
-              type: "smoothstep",
-              animated: false,
-            });
-          }
-        }
-
-        // Create Task → Task edges
-        for (let i = 0; i < result.tasks.length - 1; i++) {
-          const currentTask = result.tasks[i];
-          const nextTask = result.tasks[i + 1];
-
-          if (currentTask.parentHeadNodeId === nextTask.parentHeadNodeId) {
-            edges.push({
-              id: `edge-task-${i}`,
-              source: currentTask.id,
-              target: nextTask.id,
-              type: "smoothstep",
-              animated: false,
-            });
-          }
-        }
-        // Connects head edges
-        // for (let i = 0; i < result.headNodes.length - 1; i++) {
-        //   const currentHead = result.headNodes[i];
-        //   const nextHead = result.headNodes[i + 1];
-        //
-        //   edges.push({
-        //     id: `edge-head-${i}`,
-        //     source: currentHead.id,
-        //     target: nextHead.id,
-        //     type: "smoothstep",
-        //     animated: true,  // Animate to show flow
-        //     style: {stroke: "#22c55e", strokeWidth: 2},  // Green for dependencies
-        //   });
-        // }
-
-        set({ nodes, edges });
+        set(layout);
       },
 
       toggleHeadNodeExpansion: (headNodeId) => {
@@ -263,13 +449,15 @@ export const useCanvasStore = create<CanvasStore>()(
           ),
         });
       },
+
       updateTaskStateByName: (taskName, state) => {
         set({
-          nodes: get().nodes.map((node) =>
-            node.data.name === taskName
-              ? { ...node, data: { ...node.data, state } }
-              : node,
-          ),
+          nodes: get().nodes.map((node) => {
+            if ("name" in node.data && node.data.name === taskName) {
+              return { ...node, data: { ...node.data, state } };
+            }
+            return node;
+          }),
         });
       },
 
@@ -294,15 +482,13 @@ export const useCanvasStore = create<CanvasStore>()(
       },
 
       clearCanvas: () => {
-        set({
-          nodes: [],
-          edges: [],
-        });
+        set({ nodes: [], edges: [] });
       },
     }),
     {
       name: "canvas-storage",
       partialize: (state) => ({
+        viewMode: state.viewMode,
         nodes: state.nodes.map((node) => ({
           ...node,
           data: { ...node.data, state: "idle" },

--- a/a-station-react-app/src/stores/sourceStore.ts
+++ b/a-station-react-app/src/stores/sourceStore.ts
@@ -89,9 +89,15 @@ export const useSourceStore = create<SourceStore>()(
           if (result.success) {
             set({ sources: result.data, loading: false });
 
-            // Auto-select first source if none active
             const state = get();
-            if (!state.activeSourceId && result.data.length > 0) {
+            const persisted = state.activeSourceId;
+            const stillExists = persisted && result.data.some((s) => s.id === persisted);
+
+            if (stillExists) {
+              // Persisted source is valid — just load its file tree
+              await get().fetchFileTree(workspaceId, persisted!, token);
+            } else if (result.data.length > 0) {
+              // No valid persisted source — pick the first one
               get().setActiveSource(result.data[0].id, workspaceId, token);
             }
           } else {
@@ -219,7 +225,7 @@ export const useSourceStore = create<SourceStore>()(
       },
 
       selectFile: async (workspaceId, sourceId, path, token) => {
-        set({ fileLoading: true, selectedFilePath: path });
+        set({ fileLoading: true, selectedFilePath: path, selectedFileContent: null });
 
         try {
           const result = await getFileContent(

--- a/a-station-react-app/src/types/nodes.ts
+++ b/a-station-react-app/src/types/nodes.ts
@@ -1,3 +1,23 @@
+// === Execution & View Types ===
+
+export type ExecutionState =
+  | "idle"
+  | "running"
+  | "success"
+  | "failed"
+  | "skipped";
+
+export type TaskGroupType =
+  | "pre_tasks"
+  | "roles"
+  | "tasks"
+  | "post_tasks"
+  | "handlers";
+
+export type ViewMode = "flat" | "grouped";
+
+// === Parser Output Types ===
+
 export interface PlaybookTask {
   id: string;
   name: string;
@@ -7,53 +27,9 @@ export interface PlaybookTask {
   playbookId: string;
   playbookFile: string;
   parentHeadNodeId: string;
-}
-
-export type ExecutionState =
-  | "idle"
-  | "running"
-  | "success"
-  | "failed"
-  | "skipped";
-
-export interface TaskNodeData {
-  taskId: string;
-  name: string;
-  module: string;
-  state: ExecutionState;
-  playName?: string;
-
-  playbookFile: string;
-  playbookId: string;
-  parentHeadNodeId: string;
-
-  type: "simpleTask";
-}
-
-export interface ParseResult {
-  success: boolean;
-  headNodes: HeadNode[];
-  tasks: PlaybookTask[];
-  error?: string;
-}
-
-export interface HeadNodeData {
-  playName: string;
-  playbookFile: string;
-  playbookId: string;
-  order: number;
-  state: ExecutionState;
-
-  hosts?: string | string[];
-  become?: boolean;
-  becomeUser?: string;
-  vars?: Record<string, any>;
-  tags?: string[];
-  gather_facts?: boolean;
-
-  isExpanded: boolean;
-
-  type: "headNode";
+  taskGroup: TaskGroupType;
+  roleName?: string;
+  blockType?: "block" | "rescue" | "always";
 }
 
 export interface HeadNode {
@@ -69,3 +45,93 @@ export interface HeadNode {
   tags?: string[];
   gather_facts?: boolean;
 }
+
+export interface PlaybookRole {
+  id: string;
+  name: string;
+  parentHeadNodeId: string;
+  playbookId: string;
+  playbookFile: string;
+  order: number;
+  vars?: Record<string, any>;
+  tags?: string[];
+  when?: string;
+}
+
+export interface TaskGroup {
+  id: string;
+  type: TaskGroupType;
+  parentHeadNodeId: string;
+  label: string;
+}
+
+export interface ParseResult {
+  success: boolean;
+  headNodes: HeadNode[];
+  tasks: PlaybookTask[];
+  taskGroups: TaskGroup[];
+  roles: PlaybookRole[];
+  error?: string;
+}
+
+// === React Flow Node Data Types ===
+
+export interface TaskNodeData {
+  taskId: string;
+  name: string;
+  module: string;
+  state: ExecutionState;
+  playName?: string;
+  playbookFile: string;
+  playbookId: string;
+  parentHeadNodeId: string;
+  taskGroup: TaskGroupType;
+  roleName?: string;
+  blockType?: "block" | "rescue" | "always";
+  type: "simpleTask";
+}
+
+export interface HeadNodeData {
+  playName: string;
+  playbookFile: string;
+  playbookId: string;
+  order: number;
+  state: ExecutionState;
+  hosts?: string | string[];
+  become?: boolean;
+  becomeUser?: string;
+  vars?: Record<string, any>;
+  tags?: string[];
+  gather_facts?: boolean;
+  isExpanded: boolean;
+  taskGroupSummary?: string;
+  type: "headNode";
+}
+
+export interface TaskGroupNodeData {
+  groupId: string;
+  groupType: TaskGroupType;
+  label: string;
+  parentHeadNodeId: string;
+  state: ExecutionState;
+  type: "taskGroup";
+}
+
+export interface RoleNodeData {
+  roleId: string;
+  name: string;
+  state: ExecutionState;
+  parentHeadNodeId: string;
+  playbookFile: string;
+  playbookId: string;
+  vars?: Record<string, any>;
+  tags?: string[];
+  when?: string;
+  type: "roleNode";
+}
+
+export type AnyNodeData =
+  | TaskNodeData
+  | HeadNodeData
+  | TaskGroupNodeData
+  | RoleNodeData;


### PR DESCRIPTION
## Summary
- **Enhanced YAML parser** to handle full Ansible playbook syntax: `pre_tasks`, `post_tasks`, `roles`, `handlers`, `block`/`rescue`/`always`, and `include`/`import` patterns
- **New node components**: `TaskGroupNode` (color-coded stage headers) and `RoleNode` (role display with tags/vars/when)
- **Flat & Grouped view modes** with a toggle in the Canvas UI — flat shows linear execution order, grouped organizes tasks into swimlane columns by stage
- **UI improvements**: task group badges on SimpleTaskNode, block type indicators, group summary on HeadNode, updated nav icons, source removal button

## Test plan
- [ ] Load a playbook with only `tasks` — verify flat view renders correctly (backward compat)
- [ ] Load a playbook with `pre_tasks`, `roles`, `tasks`, `post_tasks` — verify all sections appear
- [ ] Toggle between Flat and Grouped views — verify layout recalculates
- [ ] Verify role nodes display with correct emerald styling
- [ ] Verify task group badges show correct colors per stage
- [ ] Run a job and confirm WebSocket task state updates still work
- [ ] Test source removal button in file tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)