### PR TITLE
Multi playbook canvas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -301,4 +301,4 @@ Notes
 graphs
 implementation-plans
 
-.docs/
+docs/

--- a/a-station-fast-api/app/crud/user_crud.py
+++ b/a-station-fast-api/app/crud/user_crud.py
@@ -1,10 +1,12 @@
+import uuid
+from typing import Any, Optional
+
 from pydantic import EmailStr
-from sqlalchemy.orm import Session
 from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
 from app.models.user import User
 from app.schemas.user import UserCreate
-import uuid
-from typing import Optional, Any
 
 
 def get_user(db: Session, user_id: uuid.UUID) -> Optional[User]:
@@ -18,6 +20,7 @@ def get_user_by_id(db: Session, user_id: str) -> Optional[User]:
     except (ValueError, AttributeError):
         return None
 
+
 def get_user_by_email(db: Session, email: EmailStr) -> Optional[User]:
     return db.query(User).filter(User.email == email).first()
 
@@ -27,9 +30,11 @@ def get_user_by_username(db: Session, username: str) -> Optional[User]:
 
 
 def get_user_by_email_or_username(db: Session, identifier: str) -> Optional[User]:
-    return db.query(User).filter(
-        or_(User.email == identifier, User.username == identifier)
-    ).first()
+    return (
+        db.query(User)
+        .filter(or_(User.email == identifier, User.username == identifier))
+        .first()
+    )
 
 
 def get_users(db: Session, skip: int = 0, limit: int = 100) -> list[type[User]]:
@@ -38,9 +43,7 @@ def get_users(db: Session, skip: int = 0, limit: int = 100) -> list[type[User]]:
 
 def create_user(db: Session, user: UserCreate, hashed_password: str) -> User:
     db_user = User(
-        email=user.email,
-        username=user.username,
-        hashed_password=hashed_password
+        email=user.email, username=user.username, hashed_password=hashed_password
     )
     db.add(db_user)
     db.commit()
@@ -72,9 +75,10 @@ def user_exists(db: Session, email: EmailStr = None, username: str = None) -> bo
     query = db.query(User)
 
     if email and username:
-        return query.filter(
-            or_(User.email == email, User.username == username)
-        ).first() is not None
+        return (
+            query.filter(or_(User.email == email, User.username == username)).first()
+            is not None
+        )
     elif email:
         return query.filter(User.email == email).first() is not None
     elif username:

--- a/a-station-react-app/package.json
+++ b/a-station-react-app/package.json
@@ -29,6 +29,7 @@
     "react-dom": "^19.1.1",
     "react-resizable-panels": "^4.9.0",
     "socket.io-client": "^4.8.1",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.14",
     "zustand": "^5.0.8"

--- a/a-station-react-app/package.json
+++ b/a-station-react-app/package.json
@@ -27,6 +27,7 @@
     "lucide-react": "^0.546.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-resizable-panels": "^4.9.0",
     "socket.io-client": "^4.8.1",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.14",

--- a/a-station-react-app/src/api/client.ts
+++ b/a-station-react-app/src/api/client.ts
@@ -1,0 +1,75 @@
+import { useAuthStore } from "@/stores/authStore";
+
+const baseUrl = import.meta.env.VITE_BASE_URL;
+
+let refreshInFlight: Promise<boolean> | null = null;
+
+async function refreshOnce(): Promise<boolean> {
+  if (refreshInFlight) return refreshInFlight;
+
+  refreshInFlight = (async () => {
+    try {
+      const result = await useAuthStore.getState().refresh();
+      return result.success;
+    } finally {
+      refreshInFlight = null;
+    }
+  })();
+
+  return refreshInFlight;
+}
+
+function buildHeaders(token: string | null, init: RequestInit): Headers {
+  const headers = new Headers(init.headers);
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+  if (init.body !== undefined && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+  return headers;
+}
+
+export interface ApiFetchOptions extends RequestInit {
+  /** Skip the 401 → refresh → retry dance (used by auth endpoints themselves). */
+  skipAuth?: boolean;
+}
+
+/**
+ * Authenticated fetch wrapper.
+ *
+ * - Attaches `Authorization: Bearer <token>` from authStore.
+ * - Sets `credentials: "include"` so the refresh-token cookie flows.
+ * - On 401, calls authStore.refresh() once (concurrent calls coalesce),
+ *   then retries the original request with the new access token.
+ * - If refresh fails, clears auth state and hard-redirects to /login.
+ */
+export async function apiFetch(
+  path: string,
+  init: ApiFetchOptions = {},
+): Promise<Response> {
+  const { skipAuth, ...rest } = init;
+  const url = path.startsWith("http") ? path : `${baseUrl}${path}`;
+
+  const doFetch = (token: string | null) =>
+    fetch(url, {
+      ...rest,
+      headers: buildHeaders(token, rest),
+      credentials: "include",
+    });
+
+  const response = await doFetch(useAuthStore.getState().token);
+  if (response.status !== 401 || skipAuth) return response;
+
+  const refreshed = await refreshOnce();
+  if (!refreshed) {
+    useAuthStore.getState().clearToken();
+    if (
+      typeof window !== "undefined" &&
+      window.location.pathname !== "/login"
+    ) {
+      window.location.href = "/login";
+    }
+    return response;
+  }
+
+  return doFetch(useAuthStore.getState().token);
+}

--- a/a-station-react-app/src/api/job-api.ts
+++ b/a-station-react-app/src/api/job-api.ts
@@ -1,19 +1,12 @@
 import type { ApiResult, JobCreate, JobResponse } from "@/types";
-
-const baseUrl = import.meta.env.VITE_BASE_URL;
+import { apiFetch } from "@/api/client";
 
 export const startJob = async (
   jobData: JobCreate,
-  accessToken: string
 ): Promise<ApiResult<JobResponse>> => {
   try {
-    const response = await fetch(`${baseUrl}/jobs/`, {
+    const response = await apiFetch(`/jobs/`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${accessToken}`,
-      },
-      credentials: "include",
       body: JSON.stringify(jobData),
     });
 
@@ -32,17 +25,9 @@ export const startJob = async (
 
 export const getJobStatus = async (
   jobId: string,
-  accessToken: string
 ): Promise<ApiResult<JobResponse>> => {
   try {
-    const response = await fetch(`${baseUrl}/jobs/${jobId}`, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${accessToken}`,
-      },
-      credentials: "include",
-    });
+    const response = await apiFetch(`/jobs/${jobId}`, { method: "GET" });
 
     if (response.ok) {
       const data = await response.json();

--- a/a-station-react-app/src/api/source-api.ts
+++ b/a-station-react-app/src/api/source-api.ts
@@ -6,25 +6,15 @@ import type {
   FileContent,
   InventoryData,
 } from "@/types";
-
-const baseUrl = import.meta.env.VITE_BASE_URL;
+import { apiFetch } from "@/api/client";
 
 export const getSources = async (
   workspaceId: string,
-  accessToken: string,
 ): Promise<ApiResult<ProjectSource[]>> => {
   try {
-    const response = await fetch(
-      `${baseUrl}/workspaces/${workspaceId}/sources`,
-      {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${accessToken}`,
-        },
-        credentials: "include",
-      },
-    );
+    const response = await apiFetch(`/workspaces/${workspaceId}/sources`, {
+      method: "GET",
+    });
 
     if (response.ok) {
       const data = await response.json();
@@ -42,21 +32,12 @@ export const getSources = async (
 export const createSource = async (
   workspaceId: string,
   sourceData: ProjectSourceCreate,
-  accessToken: string,
 ): Promise<ApiResult<ProjectSource>> => {
   try {
-    const response = await fetch(
-      `${baseUrl}/workspaces/${workspaceId}/sources`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${accessToken}`,
-        },
-        credentials: "include",
-        body: JSON.stringify(sourceData),
-      },
-    );
+    const response = await apiFetch(`/workspaces/${workspaceId}/sources`, {
+      method: "POST",
+      body: JSON.stringify(sourceData),
+    });
 
     if (response.ok) {
       const data = await response.json();
@@ -74,18 +55,11 @@ export const createSource = async (
 export const deleteSource = async (
   workspaceId: string,
   sourceId: string,
-  accessToken: string,
 ): Promise<ApiResult<void>> => {
   try {
-    const response = await fetch(
-      `${baseUrl}/workspaces/${workspaceId}/sources/${sourceId}`,
-      {
-        method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-        credentials: "include",
-      },
+    const response = await apiFetch(
+      `/workspaces/${workspaceId}/sources/${sourceId}`,
+      { method: "DELETE" },
     );
 
     if (response.ok) {
@@ -103,18 +77,11 @@ export const deleteSource = async (
 export const syncSource = async (
   workspaceId: string,
   sourceId: string,
-  accessToken: string,
 ): Promise<ApiResult<ProjectSource>> => {
   try {
-    const response = await fetch(
-      `${baseUrl}/workspaces/${workspaceId}/sources/${sourceId}/sync`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-        credentials: "include",
-      },
+    const response = await apiFetch(
+      `/workspaces/${workspaceId}/sources/${sourceId}/sync`,
+      { method: "POST" },
     );
 
     if (response.ok) {
@@ -133,18 +100,11 @@ export const syncSource = async (
 export const getFileTree = async (
   workspaceId: string,
   sourceId: string,
-  accessToken: string,
 ): Promise<ApiResult<FileTreeNode>> => {
   try {
-    const response = await fetch(
-      `${baseUrl}/workspaces/${workspaceId}/sources/${sourceId}/tree`,
-      {
-        method: "GET",
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-        credentials: "include",
-      },
+    const response = await apiFetch(
+      `/workspaces/${workspaceId}/sources/${sourceId}/tree`,
+      { method: "GET" },
     );
 
     if (response.ok) {
@@ -164,18 +124,11 @@ export const getFileContent = async (
   workspaceId: string,
   sourceId: string,
   filePath: string,
-  accessToken: string,
 ): Promise<ApiResult<FileContent>> => {
   try {
-    const response = await fetch(
-      `${baseUrl}/workspaces/${workspaceId}/sources/${sourceId}/file?path=${encodeURIComponent(filePath)}`,
-      {
-        method: "GET",
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-        credentials: "include",
-      },
+    const response = await apiFetch(
+      `/workspaces/${workspaceId}/sources/${sourceId}/file?path=${encodeURIComponent(filePath)}`,
+      { method: "GET" },
     );
 
     if (response.ok) {
@@ -194,22 +147,15 @@ export const getFileContent = async (
 export const getInventory = async (
   workspaceId: string,
   sourceId: string,
-  accessToken: string,
   inventoryPath?: string,
 ): Promise<ApiResult<InventoryData>> => {
   try {
     const params = inventoryPath
       ? `?path=${encodeURIComponent(inventoryPath)}`
       : "";
-    const response = await fetch(
-      `${baseUrl}/workspaces/${workspaceId}/sources/${sourceId}/inventory${params}`,
-      {
-        method: "GET",
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-        credentials: "include",
-      },
+    const response = await apiFetch(
+      `/workspaces/${workspaceId}/sources/${sourceId}/inventory${params}`,
+      { method: "GET" },
     );
 
     if (response.ok) {

--- a/a-station-react-app/src/api/workspace-api.ts
+++ b/a-station-react-app/src/api/workspace-api.ts
@@ -1,20 +1,14 @@
 import type { ApiResult } from "@/types";
-import type { Workspace, WorkspaceWithMembers, WorkspaceCreate } from "@/types/workspace";
+import type {
+  Workspace,
+  WorkspaceWithMembers,
+  WorkspaceCreate,
+} from "@/types/workspace";
+import { apiFetch } from "@/api/client";
 
-const baseUrl = import.meta.env.VITE_BASE_URL;
-
-export const getWorkspaces = async (
-  accessToken: string
-): Promise<ApiResult<Workspace[]>> => {
+export const getWorkspaces = async (): Promise<ApiResult<Workspace[]>> => {
   try {
-    const response = await fetch(`${baseUrl}/workspaces/`, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${accessToken}`,
-      },
-      credentials: "include",
-    });
+    const response = await apiFetch(`/workspaces/`, { method: "GET" });
 
     if (response.ok) {
       const data = await response.json();
@@ -31,16 +25,10 @@ export const getWorkspaces = async (
 
 export const getWorkspaceById = async (
   workspaceId: string,
-  accessToken: string
 ): Promise<ApiResult<WorkspaceWithMembers>> => {
   try {
-    const response = await fetch(`${baseUrl}/workspaces/${workspaceId}`, {
+    const response = await apiFetch(`/workspaces/${workspaceId}`, {
       method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${accessToken}`,
-      },
-      credentials: "include",
     });
 
     if (response.ok) {
@@ -58,16 +46,10 @@ export const getWorkspaceById = async (
 
 export const createWorkspace = async (
   workspaceData: WorkspaceCreate,
-  accessToken: string
 ): Promise<ApiResult<Workspace>> => {
   try {
-    const response = await fetch(`${baseUrl}/workspaces/`, {
+    const response = await apiFetch(`/workspaces/`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${accessToken}`,
-      },
-      credentials: "include",
       body: JSON.stringify(workspaceData),
     });
 

--- a/a-station-react-app/src/components/Canvas/Canvas.tsx
+++ b/a-station-react-app/src/components/Canvas/Canvas.tsx
@@ -178,7 +178,7 @@ export const Canvas = () => {
       : null;
 
   return (
-    <div className="flex-1 h-full bg-muted/70 overflow-auto relative">
+    <div className="w-full h-full bg-muted/70 overflow-auto relative">
       <ReactFlow
         nodes={nodes}
         edges={edges}

--- a/a-station-react-app/src/components/Canvas/Canvas.tsx
+++ b/a-station-react-app/src/components/Canvas/Canvas.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import {
   ReactFlow,
   Background,
@@ -6,6 +6,7 @@ import {
   MiniMap,
   BackgroundVariant,
   Panel,
+  type Node,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { useCanvasStore } from "@/stores/canvasStore";
@@ -17,7 +18,7 @@ import { Button } from "@/components/ui";
 import { Play, List, Columns } from "lucide-react";
 import { useJobExecution } from "@/hooks";
 import type { FileTreeNode } from "@/types";
-import type { ViewMode } from "@/types/nodes";
+import type { ViewMode, AnyNodeData } from "@/types/nodes";
 
 function collectInventoryPaths(
   node: FileTreeNode,
@@ -57,6 +58,11 @@ const VIEW_MODE_OPTIONS: { value: ViewMode; label: string; icon: typeof List }[]
   { value: "grouped", label: "Grouped", icon: Columns },
 ];
 
+const isYamlPath = (p: string) => p.endsWith(".yml") || p.endsWith(".yaml");
+
+const playbookIdFor = (sourceId: string | null, path: string) =>
+  `${sourceId ?? "default"}::${path}`;
+
 export const Canvas = () => {
   const { executeJob } = useJobExecution();
   const { setCurrentJob } = useJobStore();
@@ -67,13 +73,16 @@ export const Canvas = () => {
     onEdgesChange,
     onConnect,
     loadFromYAML,
+    loadMultiplePlaybooks,
     clearCanvas,
     viewMode,
     setViewMode,
   } = useCanvasStore();
   const {
-    selectedFilePath,
-    selectedFileContent,
+    selectedFilePaths,
+    fileContents,
+    focusedFilePath,
+    setFocusedFile,
     activeSourceId,
     fileTree,
   } = useSourceStore();
@@ -81,16 +90,36 @@ export const Canvas = () => {
 
   const [inventoryPath, setInventoryPath] = useState<string>("");
 
-  // Reload canvas when view mode changes
+  // Reload canvas when selection / contents / view mode change
   useEffect(() => {
-    if (
-      selectedFileContent &&
-      selectedFilePath &&
-      (selectedFilePath.endsWith(".yml") || selectedFilePath.endsWith(".yaml"))
-    ) {
-      loadFromYAML(selectedFileContent, selectedFilePath, activeSourceId || "default");
+    const yamlPaths = selectedFilePaths.filter(isYamlPath);
+    if (yamlPaths.length === 0) return;
+
+    // Wait until all selected files have content cached
+    const allLoaded = yamlPaths.every((p) => fileContents[p] !== undefined);
+    if (!allLoaded) return;
+
+    if (yamlPaths.length === 1) {
+      const p = yamlPaths[0];
+      loadFromYAML(fileContents[p], p, playbookIdFor(activeSourceId, p));
+      return;
     }
-  }, [selectedFilePath, selectedFileContent, loadFromYAML, activeSourceId, viewMode]);
+
+    loadMultiplePlaybooks(
+      yamlPaths.map((p) => ({
+        content: fileContents[p],
+        filename: p,
+        id: playbookIdFor(activeSourceId, p),
+      })),
+    );
+  }, [
+    selectedFilePaths,
+    fileContents,
+    activeSourceId,
+    viewMode,
+    loadFromYAML,
+    loadMultiplePlaybooks,
+  ]);
 
   const inventoryPaths = useMemo(() => {
     if (!fileTree?.children) return [];
@@ -109,7 +138,7 @@ export const Canvas = () => {
 
   const proOptions = { hideAttribution: true };
 
-  // Count meaningful nodes (tasks + roles)
+  // Count meaningful nodes (tasks + roles + plays)
   const nodeStats = useMemo(() => {
     let tasks = 0;
     let roles = 0;
@@ -122,6 +151,32 @@ export const Canvas = () => {
     return { tasks, roles, plays };
   }, [nodes]);
 
+  // Click any node → its playbook becomes the focused one (drives YAML pane)
+  const handleNodeClick = useCallback(
+    (_: React.MouseEvent, node: Node<AnyNodeData>) => {
+      const data = node.data;
+      if (
+        data.type === "headNode" ||
+        data.type === "simpleTask" ||
+        data.type === "roleNode" ||
+        data.type === "playbookFrame"
+      ) {
+        setFocusedFile(data.playbookFile);
+      }
+      // taskGroup nodes have no playbookFile of their own — leave focus alone
+    },
+    [setFocusedFile],
+  );
+
+  // Execute uses the focused playbook, but only if it's actually a YAML
+  // that's currently on the canvas.
+  const runnablePath =
+    focusedFilePath &&
+    isYamlPath(focusedFilePath) &&
+    selectedFilePaths.includes(focusedFilePath)
+      ? focusedFilePath
+      : null;
+
   return (
     <div className="flex-1 h-full bg-muted/70 overflow-auto relative">
       <ReactFlow
@@ -130,6 +185,7 @@ export const Canvas = () => {
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}
+        onNodeClick={handleNodeClick}
         nodeTypes={nodeTypes}
         proOptions={proOptions}
         fitView
@@ -139,6 +195,7 @@ export const Canvas = () => {
         <Controls />
         <MiniMap
           nodeColor={(node) => {
+            if (node.data.type === "playbookFrame") return "transparent";
             switch (node.data.state) {
               case "running":
                 return "#3b82f6";
@@ -184,13 +241,18 @@ export const Canvas = () => {
         </Panel>
 
         {/* Top-right: File info + Execute */}
-        {selectedFilePath && nodes.length > 0 && (
+        {selectedFilePaths.length > 0 && nodes.length > 0 && (
           <Panel position="top-right" className="min-w-38">
             <div className="bg-background/90 backdrop-blur px-3 py-2 rounded-lg border text-sm space-y-2">
               <div className="flex justify-between items-center gap-3">
-                <div>
-                  <div className="font-semibold">{selectedFilePath}</div>
-                  <div className="text-xs text-muted-foreground mt-1 flex gap-2">
+                <div className="min-w-0">
+                  <div className="font-semibold truncate max-w-[260px]">
+                    {focusedFilePath ?? `${selectedFilePaths.length} playbooks`}
+                  </div>
+                  <div className="text-xs text-muted-foreground mt-1 flex gap-2 flex-wrap">
+                    {selectedFilePaths.length > 1 && (
+                      <span>{selectedFilePaths.length} playbooks</span>
+                    )}
                     {nodeStats.plays > 0 && (
                       <span>{nodeStats.plays} plays</span>
                     )}
@@ -204,11 +266,16 @@ export const Canvas = () => {
                 </div>
 
                 <Button
-                  disabled={!inventoryPath || !activeSourceId}
+                  disabled={!inventoryPath || !activeSourceId || !runnablePath}
+                  title={
+                    runnablePath
+                      ? `Run ${runnablePath}`
+                      : "Click a playbook node to choose what to run"
+                  }
                   onClick={async () => {
                     if (
                       !activeSourceId ||
-                      !selectedFilePath ||
+                      !runnablePath ||
                       !inventoryPath ||
                       !selectedWorkspace
                     )
@@ -217,7 +284,7 @@ export const Canvas = () => {
                     const job = await executeJob({
                       workspace_id: selectedWorkspace.id,
                       source_id: activeSourceId,
-                      playbook_path: selectedFilePath,
+                      playbook_path: runnablePath,
                       inventory_path: inventoryPath,
                       ansible_version: "2.17",
                     });

--- a/a-station-react-app/src/components/Canvas/Canvas.tsx
+++ b/a-station-react-app/src/components/Canvas/Canvas.tsx
@@ -11,6 +11,7 @@ import {
 import "@xyflow/react/dist/style.css";
 import { useCanvasStore } from "@/stores/canvasStore";
 import { useSourceStore } from "@/stores/sourceStore";
+import { useCanvasSessionStore } from "@/stores/canvasSessionStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useJobStore } from "@/stores/jobStore";
 import { nodeTypes } from "@/components/Canvas/nodeTypes";
@@ -60,9 +61,6 @@ const VIEW_MODE_OPTIONS: { value: ViewMode; label: string; icon: typeof List }[]
 
 const isYamlPath = (p: string) => p.endsWith(".yml") || p.endsWith(".yaml");
 
-const playbookIdFor = (sourceId: string | null, path: string) =>
-  `${sourceId ?? "default"}::${path}`;
-
 export const Canvas = () => {
   const { executeJob } = useJobExecution();
   const { setCurrentJob } = useJobStore();
@@ -72,54 +70,19 @@ export const Canvas = () => {
     onNodesChange,
     onEdgesChange,
     onConnect,
-    loadFromYAML,
-    loadMultiplePlaybooks,
     clearCanvas,
     viewMode,
     setViewMode,
   } = useCanvasStore();
-  const {
-    selectedFilePaths,
-    fileContents,
-    focusedFilePath,
-    setFocusedFile,
-    activeSourceId,
-    fileTree,
-  } = useSourceStore();
+  const { activeSourceId, fileTree } = useSourceStore();
+
+  const selection = useCanvasSessionStore((s) => s.selection);
+  const focused = useCanvasSessionStore((s) => s.focused);
+  const sessionSetFocused = useCanvasSessionStore((s) => s.setFocused);
+
   const { selectedWorkspace } = useWorkspaceStore();
 
   const [inventoryPath, setInventoryPath] = useState<string>("");
-
-  // Reload canvas when selection / contents / view mode change
-  useEffect(() => {
-    const yamlPaths = selectedFilePaths.filter(isYamlPath);
-    if (yamlPaths.length === 0) return;
-
-    // Wait until all selected files have content cached
-    const allLoaded = yamlPaths.every((p) => fileContents[p] !== undefined);
-    if (!allLoaded) return;
-
-    if (yamlPaths.length === 1) {
-      const p = yamlPaths[0];
-      loadFromYAML(fileContents[p], p, playbookIdFor(activeSourceId, p));
-      return;
-    }
-
-    loadMultiplePlaybooks(
-      yamlPaths.map((p) => ({
-        content: fileContents[p],
-        filename: p,
-        id: playbookIdFor(activeSourceId, p),
-      })),
-    );
-  }, [
-    selectedFilePaths,
-    fileContents,
-    activeSourceId,
-    viewMode,
-    loadFromYAML,
-    loadMultiplePlaybooks,
-  ]);
 
   const inventoryPaths = useMemo(() => {
     if (!fileTree?.children) return [];
@@ -138,7 +101,6 @@ export const Canvas = () => {
 
   const proOptions = { hideAttribution: true };
 
-  // Count meaningful nodes (tasks + roles + plays)
   const nodeStats = useMemo(() => {
     let tasks = 0;
     let roles = 0;
@@ -151,7 +113,6 @@ export const Canvas = () => {
     return { tasks, roles, plays };
   }, [nodes]);
 
-  // Click any node → its playbook becomes the focused one (drives YAML pane)
   const handleNodeClick = useCallback(
     (_: React.MouseEvent, node: Node<AnyNodeData>) => {
       const data = node.data;
@@ -161,20 +122,19 @@ export const Canvas = () => {
         data.type === "roleNode" ||
         data.type === "playbookFrame"
       ) {
-        setFocusedFile(data.playbookFile);
+        if (!selectedWorkspace || !activeSourceId) return;
+        sessionSetFocused(data.playbookFile, {
+          workspaceId: selectedWorkspace.id,
+          sourceId: activeSourceId,
+        });
       }
-      // taskGroup nodes have no playbookFile of their own — leave focus alone
     },
-    [setFocusedFile],
+    [selectedWorkspace, activeSourceId, sessionSetFocused],
   );
 
-  // Execute uses the focused playbook, but only if it's actually a YAML
-  // that's currently on the canvas.
   const runnablePath =
-    focusedFilePath &&
-    isYamlPath(focusedFilePath) &&
-    selectedFilePaths.includes(focusedFilePath)
-      ? focusedFilePath
+    focused && isYamlPath(focused) && selection.includes(focused)
+      ? focused
       : null;
 
   return (
@@ -241,17 +201,17 @@ export const Canvas = () => {
         </Panel>
 
         {/* Top-right: File info + Execute */}
-        {selectedFilePaths.length > 0 && nodes.length > 0 && (
+        {selection.length > 0 && nodes.length > 0 && (
           <Panel position="top-right" className="min-w-38">
             <div className="bg-background/90 backdrop-blur px-3 py-2 rounded-lg border text-sm space-y-2">
               <div className="flex justify-between items-center gap-3">
                 <div className="min-w-0">
                   <div className="font-semibold truncate max-w-[260px]">
-                    {focusedFilePath ?? `${selectedFilePaths.length} playbooks`}
+                    {focused ?? `${selection.length} playbooks`}
                   </div>
                   <div className="text-xs text-muted-foreground mt-1 flex gap-2 flex-wrap">
-                    {selectedFilePaths.length > 1 && (
-                      <span>{selectedFilePaths.length} playbooks</span>
+                    {selection.length > 1 && (
+                      <span>{selection.length} playbooks</span>
                     )}
                     {nodeStats.plays > 0 && (
                       <span>{nodeStats.plays} plays</span>

--- a/a-station-react-app/src/components/Canvas/PlaybookFrameNode.tsx
+++ b/a-station-react-app/src/components/Canvas/PlaybookFrameNode.tsx
@@ -1,0 +1,22 @@
+import type { PlaybookFrameNodeData } from "@/types/nodes";
+
+interface PlaybookFrameNodeProps {
+  data: PlaybookFrameNodeData;
+}
+
+// A backdrop "container" rendered behind a playbook's nodes so multiple
+// playbooks on the canvas read as distinct units. Inner clicks pass
+// through to real nodes (which sit at higher z-index); clicking the
+// frame body itself sets focus via Canvas onNodeClick.
+export const PlaybookFrameNode = ({ data }: PlaybookFrameNodeProps) => {
+  return (
+    <div
+      style={{ width: data.width, height: data.height }}
+      className="relative rounded-xl border-2 border-dashed border-primary/40 bg-primary/5"
+    >
+      <div className="absolute -top-3 left-4 px-2 py-0.5 rounded bg-background text-xs font-semibold text-primary border border-primary/30 shadow-sm max-w-[90%] truncate">
+        {data.playbookFile}
+      </div>
+    </div>
+  );
+};

--- a/a-station-react-app/src/components/Canvas/nodeTypes.tsx
+++ b/a-station-react-app/src/components/Canvas/nodeTypes.tsx
@@ -2,10 +2,12 @@ import { SimpleTaskNode } from "./SimpleTaskNode";
 import { HeadNode } from "./HeadNode";
 import { TaskGroupNode } from "./TaskGroupNode";
 import { RoleNode } from "./RoleNode";
+import { PlaybookFrameNode } from "./PlaybookFrameNode";
 
 export const nodeTypes = {
   simpleTask: SimpleTaskNode,
   headNode: HeadNode,
   taskGroup: TaskGroupNode,
   roleNode: RoleNode,
+  playbookFrame: PlaybookFrameNode,
 };

--- a/a-station-react-app/src/components/DashboardNavigation.tsx
+++ b/a-station-react-app/src/components/DashboardNavigation.tsx
@@ -1,26 +1,58 @@
 import { FolderTree, Server, History } from "lucide-react";
 import { Button } from "@/components/ui";
+import { ComingSoonDialog } from "./Modals/ComingSoonDialog";
 
 export const DashboardNavigation = () => {
   return (
     <div className="flex flex-col items-center w-10 h-full bg-card border-r border-border">
       <div className="flex flex-col items-center">
-        <Button className="flex items-center justify-center w-10 h-10 rounded-lg bg-muted hover:bg-accent transition-colors">
-          <span className="text-muted-foreground text-sm">
-            <FolderTree />
-          </span>
-        </Button>
-        <Button className="flex items-center justify-center w-10 h-10 rounded-lg bg-muted hover:bg-accent transition-colors">
-          <span className="text-muted-foreground text-sm">
-            <Server />
-          </span>
-        </Button>
+        <ComingSoonDialog
+          feature="Project Browser"
+          description="A unified browser for navigating across all your playbook sources and folders is in the works."
+          trigger={
+            <Button
+              aria-label="Project browser"
+              title="Project browser"
+              className="flex items-center justify-center w-10 h-10 rounded-lg bg-muted hover:bg-accent transition-colors"
+            >
+              <span className="text-muted-foreground text-sm">
+                <FolderTree />
+              </span>
+            </Button>
+          }
+        />
 
-        <Button className="flex items-center justify-center w-10 h-10 rounded-lg bg-muted hover:bg-accent transition-colors">
-          <span className="text-muted-foreground text-sm">
-            <History />
-          </span>
-        </Button>
+        <ComingSoonDialog
+          feature="Inventory Manager"
+          description="Manage hosts, groups, and variables in a visual inventory editor. Coming soon."
+          trigger={
+            <Button
+              aria-label="Inventory manager"
+              title="Inventory manager"
+              className="flex items-center justify-center w-10 h-10 rounded-lg bg-muted hover:bg-accent transition-colors"
+            >
+              <span className="text-muted-foreground text-sm">
+                <Server />
+              </span>
+            </Button>
+          }
+        />
+
+        <ComingSoonDialog
+          feature="Run History"
+          description="Browse every playbook run across this workspace, with status, logs, and diffs — on the roadmap."
+          trigger={
+            <Button
+              aria-label="Run history"
+              title="Run history"
+              className="flex items-center justify-center w-10 h-10 rounded-lg bg-muted hover:bg-accent transition-colors"
+            >
+              <span className="text-muted-foreground text-sm">
+                <History />
+              </span>
+            </Button>
+          }
+        />
       </div>
     </div>
   );

--- a/a-station-react-app/src/components/DashboardTopBar.tsx
+++ b/a-station-react-app/src/components/DashboardTopBar.tsx
@@ -1,10 +1,10 @@
-// @flow
-
 import { Link } from "@tanstack/react-router";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { Button } from "@/components/ui";
-import { Settings2, User } from "lucide-react";
+import { Cloud, Settings2, User } from "lucide-react";
 import { ThemeToggle } from "./ThemeToggle";
+import { ComingSoonDialog } from "./Modals/ComingSoonDialog";
+import { ACloudDialog } from "./Modals/ACloudDialog";
 
 export const DashboardTopBar = () => {
   const { selectedWorkspace } = useWorkspaceStore();
@@ -26,19 +26,51 @@ export const DashboardTopBar = () => {
       </div>
       <div className="flex items-center gap-0 h-10">
         <ThemeToggle />
-        <Button className="flex items-center justify-center w-10 h-10 rounded-lg bg-muted hover:bg-accent transition-colors">
-          <span className="text-muted-foreground text-sm">
-            <Settings2 />
-          </span>
-        </Button>
-        <Button className="flex items-center justify-center w-10 h-10 rounded-lg bg-muted hover:bg-accent transition-colors">
-          <span className="text-muted-foreground text-sm">
-            <User />
-          </span>
-        </Button>
-        <Button className="flex items-center justify-center h-10 rounded-lg bg-muted hover:bg-accent transition-colors">
-          <span className="text-muted-foreground text-sm">Upgrade</span>
-        </Button>
+
+        <ComingSoonDialog
+          feature="Settings"
+          description="Workspace and user settings — themes, keyboard shortcuts, integrations, and more — are on the way."
+          trigger={
+            <Button
+              aria-label="Settings"
+              title="Settings"
+              className="flex items-center justify-center w-10 h-10 rounded-lg bg-muted hover:bg-accent transition-colors"
+            >
+              <span className="text-muted-foreground text-sm">
+                <Settings2 />
+              </span>
+            </Button>
+          }
+        />
+
+        <ComingSoonDialog
+          feature="Account"
+          description="User profile, account management, and team membership are coming soon."
+          trigger={
+            <Button
+              aria-label="Account"
+              title="Account"
+              className="flex items-center justify-center w-10 h-10 rounded-lg bg-muted hover:bg-accent transition-colors"
+            >
+              <span className="text-muted-foreground text-sm">
+                <User />
+              </span>
+            </Button>
+          }
+        />
+
+        <ACloudDialog
+          trigger={
+            <Button
+              aria-label="A-Station Cloud"
+              title="A-Station Cloud — hosted version"
+              className="flex items-center gap-1.5 h-10 px-3 rounded-lg bg-primary/10 text-primary hover:bg-primary/15 transition-colors"
+            >
+              <Cloud className="w-4 h-4" />
+              <span className="text-sm font-medium">A-Station Cloud</span>
+            </Button>
+          }
+        />
       </div>
     </div>
   );

--- a/a-station-react-app/src/components/FileTree.tsx
+++ b/a-station-react-app/src/components/FileTree.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo, useState, type MouseEvent } from "react";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useSourceStore } from "@/stores/sourceStore";
+import { useCanvasSessionStore } from "@/stores/canvasSessionStore";
 import { AddSource } from "@/components/Modals/AddSource";
 import { Button } from "@/components/ui";
 import {
+  AlertCircle,
   ChevronDown,
   ChevronLeft,
   ChevronRight,
@@ -12,6 +14,7 @@ import {
   FolderOpen,
   GitBranch,
   HardDrive,
+  Loader2,
   PanelLeftOpen,
   Plus,
   RefreshCw,
@@ -42,6 +45,10 @@ interface TreeNodeProps {
   depth: number;
   selectedPaths: Set<string>;
   focusedPath: string | null;
+  fileStatuses: Record<
+    string,
+    { status: "loading" | "loaded" | "error"; error?: string }
+  >;
   onSelectFile: (path: string, isYaml: boolean, e: MouseEvent) => void;
 }
 
@@ -51,6 +58,7 @@ const TreeNode = ({
   depth,
   selectedPaths,
   focusedPath,
+  fileStatuses,
   onSelectFile,
 }: TreeNodeProps) => {
   const [expanded, setExpanded] = useState(depth < 1);
@@ -59,6 +67,7 @@ const TreeNode = ({
   const isSelected = selectedPaths.has(fullPath);
   const isFocused = focusedPath === fullPath;
   const yaml = !isDir && isYamlFile(node.name);
+  const status = fileStatuses[fullPath];
 
   if (isDir) {
     return (
@@ -90,6 +99,7 @@ const TreeNode = ({
                 depth={depth + 1}
                 selectedPaths={selectedPaths}
                 focusedPath={focusedPath}
+                fileStatuses={fileStatuses}
                 onSelectFile={onSelectFile}
               />
             ))}
@@ -99,29 +109,46 @@ const TreeNode = ({
     );
   }
 
+  const errored = status?.status === "error";
+  const loading = status?.status === "loading";
+
   return (
     <button
       onClick={(e) => onSelectFile(fullPath, yaml, e)}
       className={`flex w-full items-center gap-1.5 px-2 py-1 hover:bg-accent cursor-pointer text-left ${
-        isSelected ? "bg-primary/15" : isFocused ? "bg-accent" : ""
+        errored
+          ? "bg-destructive/10"
+          : isSelected
+            ? "bg-primary/15"
+            : isFocused
+              ? "bg-accent"
+              : ""
       }`}
       style={{ paddingLeft: `${depth * 12 + 20}px` }}
       title={
-        yaml
-          ? "Click to load • Cmd/Ctrl-click to add • Shift-click for range"
-          : "Click to preview"
+        errored
+          ? status?.error ?? "Failed to load"
+          : yaml
+            ? "Click to load • Cmd/Ctrl-click to add • Shift-click for range"
+            : "Click to preview"
       }
     >
       <File
         className={`w-4 h-4 shrink-0 ${yaml ? "text-primary" : "text-muted-foreground"}`}
       />
       <span
-        className={`text-sm truncate ${
+        className={`text-sm truncate flex-1 ${
           isSelected ? "text-foreground font-medium" : "text-foreground"
         }`}
       >
         {node.name}
       </span>
+      {loading && (
+        <Loader2 className="w-3 h-3 shrink-0 text-muted-foreground animate-spin" />
+      )}
+      {errored && (
+        <AlertCircle className="w-3 h-3 shrink-0 text-destructive" />
+      )}
     </button>
   );
 };
@@ -140,20 +167,24 @@ export const FileTree = ({
     sources,
     activeSourceId,
     fileTree,
-    selectedFilePaths,
-    focusedFilePath,
-    selectionAnchor,
     loading,
     syncLoading,
     error,
     fetchSources,
     setActiveSource,
-    setSelection,
-    setFocusedFile,
-    loadFileContents,
     syncSource,
     removeSource,
   } = useSourceStore();
+
+  const selection = useCanvasSessionStore((s) => s.selection);
+  const focused = useCanvasSessionStore((s) => s.focused);
+  const anchor = useCanvasSessionStore((s) => s.anchor);
+  const files = useCanvasSessionStore((s) => s.files);
+  const sessionReplace = useCanvasSessionStore((s) => s.replace);
+  const sessionToggle = useCanvasSessionStore((s) => s.toggle);
+  const sessionRange = useCanvasSessionStore((s) => s.range);
+  const sessionClear = useCanvasSessionStore((s) => s.clear);
+  const sessionSetFocused = useCanvasSessionStore((s) => s.setFocused);
 
   useEffect(() => {
     if (!selectedWorkspace) return;
@@ -162,7 +193,6 @@ export const FileTree = ({
 
   const activeSource = sources.find((s) => s.id === activeSourceId);
 
-  // Ordered list of YAML files for range-select math
   const orderedYamlPaths = useMemo(() => {
     if (!fileTree?.children) return [];
     const out: string[] = [];
@@ -172,79 +202,78 @@ export const FileTree = ({
     return out;
   }, [fileTree]);
 
-  const selectedSet = useMemo(
-    () => new Set(selectedFilePaths),
-    [selectedFilePaths],
-  );
+  const selectedSet = useMemo(() => new Set(selection), [selection]);
 
-  const handleSelectFile = async (
+  const fileStatuses = useMemo(() => {
+    const out: Record<
+      string,
+      { status: "loading" | "loaded" | "error"; error?: string }
+    > = {};
+    for (const [p, f] of Object.entries(files)) {
+      out[p] = { status: f.status, error: f.error };
+    }
+    return out;
+  }, [files]);
+
+  const loadingSelectedCount = useMemo(
+    () => selection.filter((p) => files[p]?.status === "loading").length,
+    [selection, files],
+  );
+  const totalSelected = selection.length;
+  const loadedSelectedCount = totalSelected - loadingSelectedCount;
+  const progressPct =
+    totalSelected > 0 ? (loadedSelectedCount / totalSelected) * 100 : 0;
+
+  const makeCtx = () => {
+    if (!selectedWorkspace || !activeSourceId) return null;
+    return { workspaceId: selectedWorkspace.id, sourceId: activeSourceId };
+  };
+
+  const handleSelectFile = (
     path: string,
     isYaml: boolean,
     e: MouseEvent,
   ) => {
-    if (!selectedWorkspace || !activeSourceId) return;
+    const ctx = makeCtx();
+    if (!ctx) return;
 
-    // Non-YAML: just preview in the YAML pane, don't touch canvas selection
     if (!isYaml) {
-      setFocusedFile(path);
-      await loadFileContents(selectedWorkspace.id, activeSourceId, [path]);
+      sessionSetFocused(path, ctx);
       return;
     }
 
     const isCmd = e.metaKey || e.ctrlKey;
     const isShift = e.shiftKey;
-    const current = selectedFilePaths;
 
-    let nextPaths: string[];
-    let nextFocused: string | null;
-    let nextAnchor: string | null = selectionAnchor;
-
-    if (isShift && selectionAnchor && orderedYamlPaths.length) {
-      const i1 = orderedYamlPaths.indexOf(selectionAnchor);
+    if (isShift && anchor && orderedYamlPaths.length) {
+      const i1 = orderedYamlPaths.indexOf(anchor);
       const i2 = orderedYamlPaths.indexOf(path);
       if (i1 >= 0 && i2 >= 0) {
         const [a, b] = i1 < i2 ? [i1, i2] : [i2, i1];
-        nextPaths = orderedYamlPaths.slice(a, b + 1);
-        nextFocused = path;
-      } else {
-        nextPaths = [path];
-        nextFocused = path;
-        nextAnchor = path;
+        const range = orderedYamlPaths.slice(a, b + 1);
+        sessionRange(range, path, ctx);
+        return;
       }
-    } else if (isCmd) {
-      if (current.includes(path)) {
-        nextPaths = current.filter((p) => p !== path);
-        nextFocused = nextPaths[0] ?? null;
-      } else {
-        nextPaths = [...current, path];
-        nextFocused = path;
-      }
-      nextAnchor = path;
-    } else {
-      nextPaths = [path];
-      nextFocused = path;
-      nextAnchor = path;
+      sessionReplace([path], ctx);
+      return;
     }
 
-    setSelection(nextPaths, nextFocused, nextAnchor);
-    if (nextPaths.length > 0) {
-      await loadFileContents(selectedWorkspace.id, activeSourceId, nextPaths);
+    if (isCmd) {
+      sessionToggle(path, ctx);
+      return;
     }
+
+    sessionReplace([path], ctx);
   };
 
-  const handleSelectAll = async () => {
-    if (!selectedWorkspace || !activeSourceId) return;
-    if (orderedYamlPaths.length === 0) return;
-    setSelection(orderedYamlPaths, orderedYamlPaths[0], orderedYamlPaths[0]);
-    await loadFileContents(
-      selectedWorkspace.id,
-      activeSourceId,
-      orderedYamlPaths,
-    );
+  const handleSelectAll = () => {
+    const ctx = makeCtx();
+    if (!ctx || orderedYamlPaths.length === 0) return;
+    sessionReplace(orderedYamlPaths, ctx);
   };
 
   const handleDeselectAll = () => {
-    setSelection([], null, null);
+    sessionClear();
   };
 
   const handleSync = async () => {
@@ -254,8 +283,6 @@ export const FileTree = ({
 
   if (!selectedWorkspace) return null;
 
-  // Collapsed rail: thin vertical strip with a single expand affordance.
-  // Keeps the panel discoverable instead of hiding it entirely.
   if (collapsed) {
     return (
       <div className="flex flex-col items-center h-full w-full bg-background border-r border-border py-2 gap-2">
@@ -410,7 +437,8 @@ export const FileTree = ({
                 path=""
                 depth={0}
                 selectedPaths={selectedSet}
-                focusedPath={focusedFilePath}
+                focusedPath={focused}
+                fileStatuses={fileStatuses}
                 onSelectFile={handleSelectFile}
               />
             ))}
@@ -422,7 +450,7 @@ export const FileTree = ({
       {orderedYamlPaths.length > 0 && (
         <div className="border-t border-border px-3 py-2 flex items-center justify-between gap-2 bg-muted/30">
           <span className="text-[11px] text-muted-foreground">
-            {selectedFilePaths.length} / {orderedYamlPaths.length} selected
+            {selection.length} / {orderedYamlPaths.length} selected
           </span>
           <div className="flex items-center gap-1">
             <button
@@ -434,11 +462,28 @@ export const FileTree = ({
             </button>
             <button
               onClick={handleDeselectAll}
-              disabled={selectedFilePaths.length === 0}
+              disabled={selection.length === 0}
               className="text-[11px] px-2 py-1 rounded hover:bg-accent text-foreground disabled:opacity-40 disabled:cursor-not-allowed"
             >
               Clear
             </button>
+          </div>
+        </div>
+      )}
+
+      {/* Bulk-load progress bar */}
+      {loadingSelectedCount > 0 && (
+        <div className="border-t border-border px-3 py-1.5 bg-muted/30">
+          <div className="flex items-center justify-between text-[10px] text-muted-foreground mb-1">
+            <span>
+              Loading {loadedSelectedCount} / {totalSelected}
+            </span>
+          </div>
+          <div className="w-full h-1 bg-border rounded-full overflow-hidden">
+            <div
+              className="h-full bg-primary transition-all duration-200"
+              style={{ width: `${progressPct}%` }}
+            />
           </div>
         </div>
       )}

--- a/a-station-react-app/src/components/FileTree.tsx
+++ b/a-station-react-app/src/components/FileTree.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState, type MouseEvent } from "react";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useSourceStore } from "@/stores/sourceStore";
 import { useAuthStore } from "@/stores/authStore";
@@ -21,25 +21,45 @@ import type { FileTreeNode } from "@/types";
 const isYamlFile = (name: string) =>
   name.endsWith(".yml") || name.endsWith(".yaml");
 
+// Depth-first walk that returns YAML file paths in their visual order.
+// Used as the ordered axis for shift-range selection.
+function collectYamlPaths(node: FileTreeNode, prefix: string): string[] {
+  const here = prefix ? `${prefix}/${node.name}` : node.name;
+  if (node.type === "file") {
+    return isYamlFile(node.name) ? [here] : [];
+  }
+  const out: string[] = [];
+  if (node.children) {
+    for (const child of node.children) {
+      out.push(...collectYamlPaths(child, here));
+    }
+  }
+  return out;
+}
+
 interface TreeNodeProps {
   node: FileTreeNode;
   path: string;
   depth: number;
-  selectedPath: string | null;
-  onSelectFile: (path: string) => void;
+  selectedPaths: Set<string>;
+  focusedPath: string | null;
+  onSelectFile: (path: string, isYaml: boolean, e: MouseEvent) => void;
 }
 
 const TreeNode = ({
   node,
   path,
   depth,
-  selectedPath,
+  selectedPaths,
+  focusedPath,
   onSelectFile,
 }: TreeNodeProps) => {
   const [expanded, setExpanded] = useState(depth < 1);
   const fullPath = path ? `${path}/${node.name}` : node.name;
   const isDir = node.type === "directory";
-  const isSelected = selectedPath === fullPath;
+  const isSelected = selectedPaths.has(fullPath);
+  const isFocused = focusedPath === fullPath;
+  const yaml = !isDir && isYamlFile(node.name);
 
   if (isDir) {
     return (
@@ -69,7 +89,8 @@ const TreeNode = ({
                 node={child}
                 path={fullPath}
                 depth={depth + 1}
-                selectedPath={selectedPath}
+                selectedPaths={selectedPaths}
+                focusedPath={focusedPath}
                 onSelectFile={onSelectFile}
               />
             ))}
@@ -81,16 +102,27 @@ const TreeNode = ({
 
   return (
     <button
-      onClick={() => onSelectFile(fullPath)}
+      onClick={(e) => onSelectFile(fullPath, yaml, e)}
       className={`flex w-full items-center gap-1.5 px-2 py-1 hover:bg-accent cursor-pointer text-left ${
-        isSelected ? "bg-accent" : ""
+        isSelected ? "bg-primary/15" : isFocused ? "bg-accent" : ""
       }`}
       style={{ paddingLeft: `${depth * 12 + 20}px` }}
+      title={
+        yaml
+          ? "Click to load • Cmd/Ctrl-click to add • Shift-click for range"
+          : "Click to preview"
+      }
     >
       <File
-        className={`w-4 h-4 shrink-0 ${isYamlFile(node.name) ? "text-primary" : "text-muted-foreground"}`}
+        className={`w-4 h-4 shrink-0 ${yaml ? "text-primary" : "text-muted-foreground"}`}
       />
-      <span className="text-sm text-foreground truncate">{node.name}</span>
+      <span
+        className={`text-sm truncate ${
+          isSelected ? "text-foreground font-medium" : "text-foreground"
+        }`}
+      >
+        {node.name}
+      </span>
     </button>
   );
 };
@@ -102,16 +134,21 @@ export const FileTree = () => {
     sources,
     activeSourceId,
     fileTree,
-    selectedFilePath,
+    selectedFilePaths,
+    focusedFilePath,
+    selectionAnchor,
     loading,
     syncLoading,
     error,
     fetchSources,
     setActiveSource,
-    selectFile,
+    setSelection,
+    setFocusedFile,
+    loadFileContents,
     syncSource,
     removeSource,
   } = useSourceStore();
+
   useEffect(() => {
     if (!selectedWorkspace || !token) return;
     fetchSources(selectedWorkspace.id, token);
@@ -119,10 +156,104 @@ export const FileTree = () => {
 
   const activeSource = sources.find((s) => s.id === activeSourceId);
 
-  const handleSelectFile = async (path: string) => {
+  // Ordered list of YAML files for range-select math
+  const orderedYamlPaths = useMemo(() => {
+    if (!fileTree?.children) return [];
+    const out: string[] = [];
+    for (const child of fileTree.children) {
+      out.push(...collectYamlPaths(child, ""));
+    }
+    return out;
+  }, [fileTree]);
+
+  const selectedSet = useMemo(
+    () => new Set(selectedFilePaths),
+    [selectedFilePaths],
+  );
+
+  const handleSelectFile = async (
+    path: string,
+    isYaml: boolean,
+    e: MouseEvent,
+  ) => {
     if (!selectedWorkspace || !token || !activeSourceId) return;
 
-    await selectFile(selectedWorkspace.id, activeSourceId, path, token);
+    // Non-YAML: just preview in the YAML pane, don't touch canvas selection
+    if (!isYaml) {
+      setFocusedFile(path);
+      await loadFileContents(
+        selectedWorkspace.id,
+        activeSourceId,
+        [path],
+        token,
+      );
+      return;
+    }
+
+    const isCmd = e.metaKey || e.ctrlKey;
+    const isShift = e.shiftKey;
+    const current = selectedFilePaths;
+
+    let nextPaths: string[];
+    let nextFocused: string | null;
+    let nextAnchor: string | null = selectionAnchor;
+
+    if (isShift && selectionAnchor && orderedYamlPaths.length) {
+      const i1 = orderedYamlPaths.indexOf(selectionAnchor);
+      const i2 = orderedYamlPaths.indexOf(path);
+      if (i1 >= 0 && i2 >= 0) {
+        const [a, b] = i1 < i2 ? [i1, i2] : [i2, i1];
+        nextPaths = orderedYamlPaths.slice(a, b + 1);
+        nextFocused = path;
+      } else {
+        nextPaths = [path];
+        nextFocused = path;
+        nextAnchor = path;
+      }
+    } else if (isCmd) {
+      if (current.includes(path)) {
+        nextPaths = current.filter((p) => p !== path);
+        nextFocused = nextPaths[0] ?? null;
+      } else {
+        nextPaths = [...current, path];
+        nextFocused = path;
+      }
+      nextAnchor = path;
+    } else {
+      nextPaths = [path];
+      nextFocused = path;
+      nextAnchor = path;
+    }
+
+    setSelection(nextPaths, nextFocused, nextAnchor);
+    if (nextPaths.length > 0) {
+      await loadFileContents(
+        selectedWorkspace.id,
+        activeSourceId,
+        nextPaths,
+        token,
+      );
+    }
+  };
+
+  const handleSelectAll = async () => {
+    if (!selectedWorkspace || !token || !activeSourceId) return;
+    if (orderedYamlPaths.length === 0) return;
+    setSelection(
+      orderedYamlPaths,
+      orderedYamlPaths[0],
+      orderedYamlPaths[0],
+    );
+    await loadFileContents(
+      selectedWorkspace.id,
+      activeSourceId,
+      orderedYamlPaths,
+      token,
+    );
+  };
+
+  const handleDeselectAll = () => {
+    setSelection([], null, null);
   };
 
   const handleSync = async () => {
@@ -255,13 +386,39 @@ export const FileTree = () => {
                 node={node}
                 path=""
                 depth={0}
-                selectedPath={selectedFilePath}
+                selectedPaths={selectedSet}
+                focusedPath={focusedFilePath}
                 onSelectFile={handleSelectFile}
               />
             ))}
           </div>
         )}
       </div>
+
+      {/* Selection footer */}
+      {orderedYamlPaths.length > 0 && (
+        <div className="border-t border-border px-3 py-2 flex items-center justify-between gap-2 bg-muted/30">
+          <span className="text-[11px] text-muted-foreground">
+            {selectedFilePaths.length} / {orderedYamlPaths.length} selected
+          </span>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={handleSelectAll}
+              className="text-[11px] px-2 py-1 rounded hover:bg-accent text-foreground"
+              title="Select all YAML files in this source"
+            >
+              All
+            </button>
+            <button
+              onClick={handleDeselectAll}
+              disabled={selectedFilePaths.length === 0}
+              className="text-[11px] px-2 py-1 rounded hover:bg-accent text-foreground disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/a-station-react-app/src/components/FileTree.tsx
+++ b/a-station-react-app/src/components/FileTree.tsx
@@ -1,17 +1,18 @@
 import { useEffect, useMemo, useState, type MouseEvent } from "react";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useSourceStore } from "@/stores/sourceStore";
-import { useAuthStore } from "@/stores/authStore";
 import { AddSource } from "@/components/Modals/AddSource";
 import { Button } from "@/components/ui";
 import {
   ChevronDown,
+  ChevronLeft,
   ChevronRight,
   File,
   Folder,
   FolderOpen,
   GitBranch,
   HardDrive,
+  PanelLeftOpen,
   Plus,
   RefreshCw,
   Trash2,
@@ -21,8 +22,6 @@ import type { FileTreeNode } from "@/types";
 const isYamlFile = (name: string) =>
   name.endsWith(".yml") || name.endsWith(".yaml");
 
-// Depth-first walk that returns YAML file paths in their visual order.
-// Used as the ordered axis for shift-range selection.
 function collectYamlPaths(node: FileTreeNode, prefix: string): string[] {
   const here = prefix ? `${prefix}/${node.name}` : node.name;
   if (node.type === "file") {
@@ -127,9 +126,16 @@ const TreeNode = ({
   );
 };
 
-export const FileTree = () => {
+interface FileTreeProps {
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
+}
+
+export const FileTree = ({
+  collapsed = false,
+  onToggleCollapse,
+}: FileTreeProps) => {
   const { selectedWorkspace } = useWorkspaceStore();
-  const token = useAuthStore((state) => state.token);
   const {
     sources,
     activeSourceId,
@@ -150,9 +156,9 @@ export const FileTree = () => {
   } = useSourceStore();
 
   useEffect(() => {
-    if (!selectedWorkspace || !token) return;
-    fetchSources(selectedWorkspace.id, token);
-  }, [selectedWorkspace?.id, token, fetchSources]);
+    if (!selectedWorkspace) return;
+    fetchSources(selectedWorkspace.id);
+  }, [selectedWorkspace?.id, fetchSources]);
 
   const activeSource = sources.find((s) => s.id === activeSourceId);
 
@@ -176,17 +182,12 @@ export const FileTree = () => {
     isYaml: boolean,
     e: MouseEvent,
   ) => {
-    if (!selectedWorkspace || !token || !activeSourceId) return;
+    if (!selectedWorkspace || !activeSourceId) return;
 
     // Non-YAML: just preview in the YAML pane, don't touch canvas selection
     if (!isYaml) {
       setFocusedFile(path);
-      await loadFileContents(
-        selectedWorkspace.id,
-        activeSourceId,
-        [path],
-        token,
-      );
+      await loadFileContents(selectedWorkspace.id, activeSourceId, [path]);
       return;
     }
 
@@ -227,28 +228,18 @@ export const FileTree = () => {
 
     setSelection(nextPaths, nextFocused, nextAnchor);
     if (nextPaths.length > 0) {
-      await loadFileContents(
-        selectedWorkspace.id,
-        activeSourceId,
-        nextPaths,
-        token,
-      );
+      await loadFileContents(selectedWorkspace.id, activeSourceId, nextPaths);
     }
   };
 
   const handleSelectAll = async () => {
-    if (!selectedWorkspace || !token || !activeSourceId) return;
+    if (!selectedWorkspace || !activeSourceId) return;
     if (orderedYamlPaths.length === 0) return;
-    setSelection(
-      orderedYamlPaths,
-      orderedYamlPaths[0],
-      orderedYamlPaths[0],
-    );
+    setSelection(orderedYamlPaths, orderedYamlPaths[0], orderedYamlPaths[0]);
     await loadFileContents(
       selectedWorkspace.id,
       activeSourceId,
       orderedYamlPaths,
-      token,
     );
   };
 
@@ -257,14 +248,37 @@ export const FileTree = () => {
   };
 
   const handleSync = async () => {
-    if (!selectedWorkspace || !token || !activeSourceId) return;
-    await syncSource(selectedWorkspace.id, activeSourceId, token);
+    if (!selectedWorkspace || !activeSourceId) return;
+    await syncSource(selectedWorkspace.id, activeSourceId);
   };
 
   if (!selectedWorkspace) return null;
 
+  // Collapsed rail: thin vertical strip with a single expand affordance.
+  // Keeps the panel discoverable instead of hiding it entirely.
+  if (collapsed) {
+    return (
+      <div className="flex flex-col items-center h-full w-full bg-background border-r border-border py-2 gap-2">
+        <button
+          onClick={onToggleCollapse}
+          className="flex items-center justify-center w-8 h-8 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+          title="Expand file tree"
+          aria-label="Expand file tree"
+        >
+          <PanelLeftOpen className="w-4 h-4" />
+        </button>
+        <div
+          className="mt-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground select-none"
+          style={{ writingMode: "vertical-rl" }}
+        >
+          Files
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex flex-col w-64 h-full bg-background border-r border-border">
+    <div className="flex flex-col w-full h-full bg-background border-r border-border min-w-0">
       {/* Source selector header */}
       <div className="px-3 py-2 border-b border-border space-y-2">
         <div className="flex items-center justify-between">
@@ -274,11 +288,12 @@ export const FileTree = () => {
               <Button
                 className="flex items-center justify-center w-6 h-6 rounded bg-transparent hover:bg-destructive/10 transition-colors"
                 onClick={() => {
-                  if (!token || !activeSourceId) return;
+                  if (!activeSourceId) return;
                   const source = sources.find((s) => s.id === activeSourceId);
                   if (!source) return;
-                  if (!window.confirm(`Remove source "${source.name}"?`)) return;
-                  removeSource(selectedWorkspace.id, activeSourceId, token);
+                  if (!window.confirm(`Remove source "${source.name}"?`))
+                    return;
+                  removeSource(selectedWorkspace.id, activeSourceId);
                 }}
                 title="Remove source"
               >
@@ -293,6 +308,16 @@ export const FileTree = () => {
                 </Button>
               }
             />
+            {onToggleCollapse && (
+              <Button
+                onClick={onToggleCollapse}
+                className="flex items-center justify-center w-6 h-6 rounded bg-transparent hover:bg-accent transition-colors ml-0.5"
+                title="Collapse file tree"
+                aria-label="Collapse file tree"
+              >
+                <ChevronLeft className="w-3.5 h-3.5 text-muted-foreground" />
+              </Button>
+            )}
           </div>
         </div>
 
@@ -301,8 +326,8 @@ export const FileTree = () => {
             <select
               value={activeSourceId || ""}
               onChange={(e) => {
-                if (e.target.value && token) {
-                  setActiveSource(e.target.value, selectedWorkspace.id, token);
+                if (e.target.value) {
+                  setActiveSource(e.target.value, selectedWorkspace.id);
                 }
               }}
               className="flex-1 text-sm bg-muted border border-border rounded px-2 py-1 text-foreground truncate"
@@ -368,9 +393,7 @@ export const FileTree = () => {
           <div className="p-4 text-sm text-muted-foreground">Loading...</div>
         )}
 
-        {error && (
-          <div className="p-4 text-xs text-destructive">{error}</div>
-        )}
+        {error && <div className="p-4 text-xs text-destructive">{error}</div>}
 
         {!loading && !error && sources.length === 0 && (
           <div className="p-4 text-sm text-muted-foreground">

--- a/a-station-react-app/src/components/Modals/ACloudDialog.tsx
+++ b/a-station-react-app/src/components/Modals/ACloudDialog.tsx
@@ -1,0 +1,71 @@
+import { useState, type ReactNode } from "react";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Cloud, Check } from "lucide-react";
+
+interface ACloudDialogProps {
+  trigger: ReactNode;
+}
+
+const BULLETS = [
+  "Zero-setup hosted control plane — no self-hosting, no upgrades",
+  "Team workspaces with SSO and fine-grained access control",
+  "Scheduled runs, approvals, and audit logs out of the box",
+  "Priority support from the A-Station team",
+];
+
+// Upsell modal for the hosted offering. Replaces the old dead "Upgrade"
+// button with a concrete pitch instead of a no-op.
+export const ACloudDialog = ({ trigger }: ACloudDialogProps) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent className="sm:max-w-[520px]">
+        <DialogHeader>
+          <div className="flex items-center gap-2.5 mb-1">
+            <div className="flex items-center justify-center w-9 h-9 rounded-lg bg-primary/10 text-primary">
+              <Cloud className="w-4 h-4" />
+            </div>
+            <DialogTitle>A-Station Cloud</DialogTitle>
+          </div>
+          <DialogDescription className="pt-1">
+            Get everything you love about A-Station without running the
+            infrastructure yourself. Cloud is in private beta — join the
+            waitlist to get early access.
+          </DialogDescription>
+        </DialogHeader>
+
+        <ul className="space-y-2.5 py-2">
+          {BULLETS.map((b) => (
+            <li key={b} className="flex items-start gap-2.5 text-sm">
+              <Check className="w-4 h-4 text-primary mt-0.5 shrink-0" />
+              <span className="text-foreground">{b}</span>
+            </li>
+          ))}
+        </ul>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline" type="button">
+              Maybe later
+            </Button>
+          </DialogClose>
+          <Button type="button" disabled title="Waitlist coming soon">
+            Join waitlist
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/a-station-react-app/src/components/Modals/AddSource.tsx
+++ b/a-station-react-app/src/components/Modals/AddSource.tsx
@@ -11,7 +11,6 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { useAuthStore } from "@/stores/authStore";
 import { useSourceStore } from "@/stores/sourceStore";
 
 interface AddSourceProps {
@@ -25,7 +24,6 @@ export const AddSource = ({
   onSuccess,
   trigger,
 }: AddSourceProps) => {
-  const token = useAuthStore((state) => state.token);
   const addSource = useSourceStore((state) => state.addSource);
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
@@ -54,25 +52,16 @@ export const AddSource = ({
       return;
     }
 
-    if (!token) {
-      setError("Not authenticated");
-      return;
-    }
-
     setLoading(true);
     setError(null);
 
-    const result = await addSource(
-      workspaceId,
-      {
-        name: name.trim(),
-        source_type: sourceType,
-        ...(sourceType === "git"
-          ? { git_url: gitUrl.trim(), git_branch: gitBranch.trim() || "main" }
-          : { local_path: localPath.trim() }),
-      },
-      token,
-    );
+    const result = await addSource(workspaceId, {
+      name: name.trim(),
+      source_type: sourceType,
+      ...(sourceType === "git"
+        ? { git_url: gitUrl.trim(), git_branch: gitBranch.trim() || "main" }
+        : { local_path: localPath.trim() }),
+    });
 
     setLoading(false);
 

--- a/a-station-react-app/src/components/Modals/ComingSoonDialog.tsx
+++ b/a-station-react-app/src/components/Modals/ComingSoonDialog.tsx
@@ -1,0 +1,57 @@
+import { useState, type ReactNode } from "react";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Sparkles } from "lucide-react";
+
+interface ComingSoonDialogProps {
+  feature: string;
+  description?: string;
+  trigger: ReactNode;
+}
+
+// Lightweight placeholder modal for features that aren't wired up yet.
+// Replaces dead affordances (buttons that used to do nothing) with a
+// clear signal: "this is planned, not broken."
+export const ComingSoonDialog = ({
+  feature,
+  description,
+  trigger,
+}: ComingSoonDialogProps) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent className="sm:max-w-[440px]">
+        <DialogHeader>
+          <div className="flex items-center gap-2.5 mb-1">
+            <div className="flex items-center justify-center w-9 h-9 rounded-lg bg-primary/10 text-primary">
+              <Sparkles className="w-4 h-4" />
+            </div>
+            <DialogTitle>{feature}</DialogTitle>
+          </div>
+          <DialogDescription className="pt-1">
+            {description ??
+              `${feature} is on the roadmap but not available in this build yet. Stay tuned — it's coming soon.`}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline" type="button">
+              Got it
+            </Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/a-station-react-app/src/components/Modals/CreateWorkspace.tsx
+++ b/a-station-react-app/src/components/Modals/CreateWorkspace.tsx
@@ -11,7 +11,6 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { useAuthStore } from "@/stores/authStore";
 import { createWorkspace } from "@/api/workspace-api";
 
 interface CreateWorkspaceProps {
@@ -23,7 +22,6 @@ export const CreateWorkspace = ({
   onSuccess,
   trigger,
 }: CreateWorkspaceProps) => {
-  const token = useAuthStore((state) => state.token);
   const [open, setOpen] = useState(false);
   const [workspaceName, setWorkspaceName] = useState("");
   const [loading, setLoading] = useState(false);
@@ -37,19 +35,11 @@ export const CreateWorkspace = ({
       return;
     }
 
-    if (!token) {
-      setError("Not authenticated");
-      return;
-    }
-
     setLoading(true);
     setError(null);
 
     try {
-      const result = await createWorkspace(
-        { name: workspaceName.trim() },
-        token,
-      );
+      const result = await createWorkspace({ name: workspaceName.trim() });
 
       if (result.success) {
         setOpen(false);

--- a/a-station-react-app/src/components/ToolBar/SecondaryToolbar.tsx
+++ b/a-station-react-app/src/components/ToolBar/SecondaryToolbar.tsx
@@ -87,7 +87,7 @@ export const SecondaryToolbar = ({
       </div>
 
       {/* Tab Content */}
-      <div className="flex-1 overflow-hidden h-full">
+      <div className="flex-1 overflow-hidden min-h-0">
         {activeTab === "logs" && <PlaybookLogs jobId={currentJob?.id} />}
         {activeTab === "yaml" && <YamlTab />}
         {activeTab === "llm" && (

--- a/a-station-react-app/src/components/ToolBar/SecondaryToolbar.tsx
+++ b/a-station-react-app/src/components/ToolBar/SecondaryToolbar.tsx
@@ -1,16 +1,47 @@
 import { useState } from "react";
+import { ChevronRight, PanelRightOpen } from "lucide-react";
 import { PlaybookLogs } from "../PlaybookLogs.tsx";
 import { YamlTab } from "@/components/ToolBar/YamlTab.tsx";
 import { useJobStore } from "@/stores/jobStore.ts";
 
 type Tab = "logs" | "yaml" | "llm";
 
-export const SecondaryToolbar = () => {
+interface SecondaryToolbarProps {
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
+}
+
+export const SecondaryToolbar = ({
+  collapsed = false,
+  onToggleCollapse,
+}: SecondaryToolbarProps) => {
   const { currentJob } = useJobStore();
   const [activeTab, setActiveTab] = useState<Tab>("yaml");
 
+  // Collapsed rail: mirror of the FileTree collapsed state.
+  if (collapsed) {
+    return (
+      <div className="flex flex-col items-center h-full w-full bg-card border-l border-border py-2 gap-2">
+        <button
+          onClick={onToggleCollapse}
+          className="flex items-center justify-center w-8 h-8 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+          title="Expand tools panel"
+          aria-label="Expand tools panel"
+        >
+          <PanelRightOpen className="w-4 h-4" />
+        </button>
+        <div
+          className="mt-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground select-none"
+          style={{ writingMode: "vertical-rl" }}
+        >
+          Tools
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex flex-col w-96 h-full bg-card border-l border-border">
+    <div className="flex flex-col w-full h-full bg-card border-l border-border min-w-0">
       {/* Tab Headers */}
       <div className="flex items-center border-b border-border">
         <button
@@ -43,6 +74,16 @@ export const SecondaryToolbar = () => {
         >
           LLM
         </button>
+        {onToggleCollapse && (
+          <button
+            onClick={onToggleCollapse}
+            className="flex items-center justify-center w-9 h-full px-2 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors border-l border-border"
+            title="Collapse tools panel"
+            aria-label="Collapse tools panel"
+          >
+            <ChevronRight className="w-4 h-4" />
+          </button>
+        )}
       </div>
 
       {/* Tab Content */}

--- a/a-station-react-app/src/components/ToolBar/YamlCodeViewer.tsx
+++ b/a-station-react-app/src/components/ToolBar/YamlCodeViewer.tsx
@@ -8,14 +8,12 @@ interface YamlCodeViewerProps {
   readOnly?: boolean;
   highlightedLines?: number[];
   executionState?: Map<number, "running" | "success" | "error">;
-  height?: string;
 }
 
 export function YamlCodeViewer({
   content,
   onChange,
   readOnly = true,
-  height = "100%",
 }: YamlCodeViewerProps) {
   const extensions = useMemo(() => {
     const exts = [yaml()];
@@ -27,8 +25,8 @@ export function YamlCodeViewer({
   return (
     <div className="h-full w-full overflow-hidden">
       <CodeMirror
+        className="h-full"
         value={safeContent}
-        height={height}
         extensions={extensions}
         onChange={onChange}
         editable={!readOnly}

--- a/a-station-react-app/src/components/ToolBar/YamlTab.tsx
+++ b/a-station-react-app/src/components/ToolBar/YamlTab.tsx
@@ -1,12 +1,16 @@
 import { YamlCodeViewer } from "@/components";
-import { useSourceStore } from "@/stores/sourceStore";
-import { File } from "lucide-react";
+import { useCanvasSessionStore } from "@/stores/canvasSessionStore";
+import { File, Loader2, AlertCircle } from "lucide-react";
 
 export function YamlTab() {
-  const { focusedFilePath, fileContents, fileLoading } = useSourceStore();
+  const focused = useCanvasSessionStore((s) => s.focused);
+  const file = useCanvasSessionStore((s) =>
+    s.focused ? s.files[s.focused] : undefined,
+  );
 
-  const content =
-    focusedFilePath !== null ? (fileContents[focusedFilePath] ?? "") : "";
+  const content = file?.status === "loaded" ? (file.content ?? "") : "";
+  const loading = file?.status === "loading";
+  const error = file?.status === "error" ? file.error : null;
 
   return (
     <div className="h-full w-full flex flex-col">
@@ -14,19 +18,25 @@ export function YamlTab() {
         <div className="flex items-center gap-2 min-w-0">
           <File className="w-3 h-3 text-muted-foreground shrink-0" />
           <span className="text-xs font-medium text-muted-foreground truncate">
-            {focusedFilePath || "Click a file or node to preview"}
+            {focused || "Click a file or node to preview"}
           </span>
         </div>
-        {fileLoading && (
-          <span className="text-xs text-muted-foreground shrink-0">
-            Loading...
-          </span>
+        {loading && (
+          <Loader2 className="w-3 h-3 shrink-0 animate-spin text-muted-foreground" />
+        )}
+        {error && (
+          <AlertCircle className="w-3 h-3 shrink-0 text-destructive" />
         )}
       </div>
-
-      <div className="flex-1 min-h-0 overflow-hidden">
-        <YamlCodeViewer content={content} readOnly height="100%" />
-      </div>
+      {error ? (
+        <div className="flex-1 flex items-center justify-center text-xs text-destructive px-4 text-center">
+          Failed to load: {error}
+        </div>
+      ) : (
+        <div className="flex-1 min-h-0 overflow-hidden">
+          <YamlCodeViewer content={content} readOnly />
+        </div>
+      )}
     </div>
   );
 }

--- a/a-station-react-app/src/components/ToolBar/YamlTab.tsx
+++ b/a-station-react-app/src/components/ToolBar/YamlTab.tsx
@@ -3,22 +3,24 @@ import { useSourceStore } from "@/stores/sourceStore";
 import { File } from "lucide-react";
 
 export function YamlTab() {
-  const { selectedFilePath, selectedFileContent, fileLoading } =
-    useSourceStore();
+  const { focusedFilePath, fileContents, fileLoading } = useSourceStore();
 
-  const content = selectedFileContent ?? "";
+  const content =
+    focusedFilePath !== null ? (fileContents[focusedFilePath] ?? "") : "";
 
   return (
     <div className="h-full w-full flex flex-col">
       <div className="flex items-center justify-between px-3 py-2 border-b border-border bg-muted/30">
-        <div className="flex items-center gap-2">
-          <File className="w-3 h-3 text-muted-foreground" />
-          <span className="text-xs font-medium text-muted-foreground truncate max-w-[250px]">
-            {selectedFilePath || "No file selected"}
+        <div className="flex items-center gap-2 min-w-0">
+          <File className="w-3 h-3 text-muted-foreground shrink-0" />
+          <span className="text-xs font-medium text-muted-foreground truncate">
+            {focusedFilePath || "Click a file or node to preview"}
           </span>
         </div>
         {fileLoading && (
-          <span className="text-xs text-muted-foreground">Loading...</span>
+          <span className="text-xs text-muted-foreground shrink-0">
+            Loading...
+          </span>
         )}
       </div>
 

--- a/a-station-react-app/src/components/index.tsx
+++ b/a-station-react-app/src/components/index.tsx
@@ -14,3 +14,5 @@ export { DashboardNavigation } from "./DashboardNavigation";
 export { YamlCodeViewer } from "./ToolBar/YamlCodeViewer";
 export { ThemeToggle } from "./ThemeToggle";
 export { AddSource } from "./Modals/AddSource";
+export { ComingSoonDialog } from "./Modals/ComingSoonDialog";
+export { ACloudDialog } from "./Modals/ACloudDialog";

--- a/a-station-react-app/src/components/ui/index.tsx
+++ b/a-station-react-app/src/components/ui/index.tsx
@@ -43,3 +43,9 @@ export {
   DialogTitle,
   DialogTrigger,
 } from "./dialog";
+
+export {
+  ResizablePanelGroup,
+  ResizablePanel,
+  ResizableHandle,
+} from "./resizable";

--- a/a-station-react-app/src/components/ui/resizable.tsx
+++ b/a-station-react-app/src/components/ui/resizable.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import { GripVertical } from "lucide-react";
+import * as ResizablePrimitive from "react-resizable-panels";
+
+import { cn } from "@/lib/utils";
+
+// Thin wrappers around react-resizable-panels v4 so the rest of the app
+// keeps the familiar "PanelGroup / Panel / Handle" naming.
+function ResizablePanelGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof ResizablePrimitive.Group>) {
+  return (
+    <ResizablePrimitive.Group
+      data-slot="resizable-panel-group"
+      className={cn("flex h-full w-full", className)}
+      {...props}
+    />
+  );
+}
+
+const ResizablePanel = ResizablePrimitive.Panel;
+
+function ResizableHandle({
+  withHandle,
+  className,
+  ...props
+}: React.ComponentProps<typeof ResizablePrimitive.Separator> & {
+  withHandle?: boolean;
+}) {
+  return (
+    <ResizablePrimitive.Separator
+      data-slot="resizable-handle"
+      className={cn(
+        "group relative flex w-px items-center justify-center bg-border transition-colors hover:bg-primary/60",
+        // Larger invisible hit target so dragging is forgiving.
+        "after:absolute after:inset-y-0 after:left-1/2 after:w-2 after:-translate-x-1/2",
+        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1",
+        className,
+      )}
+      {...props}
+    >
+      {withHandle && (
+        <div className="z-10 flex h-5 w-3 items-center justify-center rounded-sm border bg-border text-muted-foreground group-hover:text-foreground">
+          <GripVertical className="size-2.5" />
+        </div>
+      )}
+    </ResizablePrimitive.Separator>
+  );
+}
+
+export { ResizablePanelGroup, ResizablePanel, ResizableHandle };

--- a/a-station-react-app/src/components/ui/sonner.tsx
+++ b/a-station-react-app/src/components/ui/sonner.tsx
@@ -1,0 +1,20 @@
+import { Toaster as Sonner, type ToasterProps } from "sonner";
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  return (
+    <Sonner
+      theme="system"
+      className="toaster group"
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  );
+};
+
+export { Toaster };

--- a/a-station-react-app/src/hooks/useJobExecution.ts
+++ b/a-station-react-app/src/hooks/useJobExecution.ts
@@ -200,7 +200,7 @@ export const useJobExecution = (options: UseJobExecutionOptions = {}) => {
 
       try {
         // Start the job via HTTP
-        const result = await startJob(jobData, token);
+        const result = await startJob(jobData);
 
         if (!result.success) {
           setState((prev) => ({

--- a/a-station-react-app/src/main.tsx
+++ b/a-station-react-app/src/main.tsx
@@ -4,6 +4,8 @@ import { RouterProvider } from "@tanstack/react-router";
 import { router } from "./routes";
 import "./index.css";
 import { useAuthInit } from "@/hooks/useAuthInit";
+import { Toaster } from "@/components/ui/sonner";
+import { initCanvasRebuild } from "@/stores/canvasRebuild";
 
 function App() {
   const { isInitialized } = useAuthInit();
@@ -16,8 +18,15 @@ function App() {
     );
   }
 
-  return <RouterProvider router={router} />;
+  return (
+    <>
+      <RouterProvider router={router} />
+      <Toaster position="top-center" richColors closeButton />
+    </>
+  );
 }
+
+initCanvasRebuild();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/a-station-react-app/src/pages/Dashboard.tsx
+++ b/a-station-react-app/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
+import type { PanelImperativeHandle } from "react-resizable-panels";
 import {
   Canvas,
   DashboardTopBar,
@@ -7,11 +8,40 @@ import {
   SecondaryToolbar,
   DashboardNavigation,
 } from "@/components";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+
+// Threshold under which a panel is considered collapsed. Must sit between
+// `collapsedSize` (3%) and `minSize` (14%) so we flip the flag exactly when
+// the panel snaps to its collapsed state.
+const COLLAPSED_THRESHOLD_PCT = 5;
 
 export const Dashboard = () => {
   const navigate = useNavigate({ from: "/dashboard" });
   const { selectedWorkspace } = useWorkspaceStore();
+
+  const fileTreePanelRef = useRef<PanelImperativeHandle>(null);
+  const secondaryPanelRef = useRef<PanelImperativeHandle>(null);
+  const [fileTreeCollapsed, setFileTreeCollapsed] = useState(false);
+  const [secondaryCollapsed, setSecondaryCollapsed] = useState(false);
+
+  const toggleFileTree = useCallback(() => {
+    const panel = fileTreePanelRef.current;
+    if (!panel) return;
+    if (panel.isCollapsed()) panel.expand();
+    else panel.collapse();
+  }, []);
+
+  const toggleSecondary = useCallback(() => {
+    const panel = secondaryPanelRef.current;
+    if (!panel) return;
+    if (panel.isCollapsed()) panel.expand();
+    else panel.collapse();
+  }, []);
 
   useEffect(() => {
     if (!selectedWorkspace) {
@@ -28,13 +58,55 @@ export const Dashboard = () => {
   }
 
   return (
-    <main className={"flex flex-col w-screen h-screen -mx-auto"}>
+    <main className="flex flex-col w-screen h-screen">
       <DashboardTopBar />
-      <div className={"overflow-hidden flex flex-row justify-between flex-1"}>
+      <div className="flex flex-row flex-1 min-h-0 overflow-hidden">
         <DashboardNavigation />
-        <FileTree />
-        <Canvas />
-        <SecondaryToolbar />
+        <ResizablePanelGroup orientation="horizontal" className="flex-1">
+          <ResizablePanel
+            panelRef={fileTreePanelRef}
+            id="file-tree"
+            defaultSize="18%"
+            minSize="14%"
+            maxSize="36%"
+            collapsible
+            collapsedSize="3%"
+            onResize={(size) =>
+              setFileTreeCollapsed(size.asPercentage < COLLAPSED_THRESHOLD_PCT)
+            }
+          >
+            <FileTree
+              collapsed={fileTreeCollapsed}
+              onToggleCollapse={toggleFileTree}
+            />
+          </ResizablePanel>
+
+          <ResizableHandle withHandle />
+
+          <ResizablePanel id="canvas" defaultSize="60%" minSize="30%">
+            <Canvas />
+          </ResizablePanel>
+
+          <ResizableHandle withHandle />
+
+          <ResizablePanel
+            panelRef={secondaryPanelRef}
+            id="secondary-toolbar"
+            defaultSize="22%"
+            minSize="16%"
+            maxSize="45%"
+            collapsible
+            collapsedSize="3%"
+            onResize={(size) =>
+              setSecondaryCollapsed(size.asPercentage < COLLAPSED_THRESHOLD_PCT)
+            }
+          >
+            <SecondaryToolbar
+              collapsed={secondaryCollapsed}
+              onToggleCollapse={toggleSecondary}
+            />
+          </ResizablePanel>
+        </ResizablePanelGroup>
       </div>
     </main>
   );

--- a/a-station-react-app/src/pages/WorkspaceSelect.tsx
+++ b/a-station-react-app/src/pages/WorkspaceSelect.tsx
@@ -1,11 +1,9 @@
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { useAuthStore } from "@/stores/authStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
-import type { Workspace, WorkspaceWithMembers } from "@/types/workspace";
+import type { Workspace } from "@/types/workspace";
 import {
   Card,
-  CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
@@ -15,21 +13,13 @@ import { Button } from "@/components";
 import { Plus } from "lucide-react";
 
 export const WorkspaceSelect = () => {
-  const token = useAuthStore((state) => state.token);
-
   const navigate = useNavigate({ from: "/workspaces/select" });
   const { setSelectedWorkspace, fetchWorkspaces, workspaces, loading, error } =
     useWorkspaceStore();
 
-  const [workspaceDetails, setWorkspaceDetails] = useState<
-    Map<string, WorkspaceWithMembers>
-  >(new Map());
-
   useEffect(() => {
-    if (token) {
-      fetchWorkspaces(token);
-    }
-  }, [fetchWorkspaces, token]);
+    fetchWorkspaces();
+  }, [fetchWorkspaces]);
 
   const handleSelectWorkspace = (workspace: Workspace) => {
     setSelectedWorkspace(workspace);
@@ -89,65 +79,21 @@ export const WorkspaceSelect = () => {
           </Card>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {workspaces.map((workspace) => {
-              const details = workspaceDetails.get(workspace.id);
-              const memberCount = details?.members.length || 0;
-              const isOwner = details?.owner_id === token;
-
-              return (
-                <Card
-                  key={workspace.id}
-                  className="hover:border-primary transition-colors cursor-pointer"
-                  onClick={() => handleSelectWorkspace(workspace)}
-                >
-                  <CardHeader>
-                    <CardTitle className="flex items-center justify-between">
-                      {workspace.name}
-                      {isOwner && (
-                        <span className="text-xs font-normal bg-primary/10 text-primary px-2 py-1 rounded">
-                          Owner
-                        </span>
-                      )}
-                    </CardTitle>
-                    <CardDescription>
-                      Created{" "}
-                      {new Date(workspace.created_at).toLocaleDateString()}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="space-y-4">
-                      <div>
-                        <div className="text-sm font-medium text-foreground mb-2">
-                          Members ({memberCount})
-                        </div>
-                        {details && details.members.length > 0 ? (
-                          <div className="flex flex-wrap gap-2">
-                            {details.members.slice(0, 3).map((member) => (
-                              <div
-                                key={member.user_id}
-                                className="text-xs bg-secondary text-secondary-foreground px-2 py-1 rounded"
-                                title={`${member.username} - ${member.role}`}
-                              >
-                                {member.username}
-                              </div>
-                            ))}
-                            {details.members.length > 3 && (
-                              <div className="text-xs bg-secondary text-secondary-foreground px-2 py-1 rounded">
-                                +{details.members.length - 3} more
-                              </div>
-                            )}
-                          </div>
-                        ) : (
-                          <div className="text-xs text-muted-foreground">
-                            Loading members...
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-              );
-            })}
+            {workspaces.map((workspace) => (
+              <Card
+                key={workspace.id}
+                className="hover:border-primary transition-colors cursor-pointer"
+                onClick={() => handleSelectWorkspace(workspace)}
+              >
+                <CardHeader>
+                  <CardTitle>{workspace.name}</CardTitle>
+                  <CardDescription>
+                    Created{" "}
+                    {new Date(workspace.created_at).toLocaleDateString()}
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+            ))}
           </div>
         )}
       </div>

--- a/a-station-react-app/src/stores/canvasRebuild.ts
+++ b/a-station-react-app/src/stores/canvasRebuild.ts
@@ -1,0 +1,59 @@
+import { useCanvasSessionStore } from "./canvasSessionStore";
+import { useCanvasStore } from "./canvasStore";
+
+function playbookIdFor(path: string): string {
+  return `session::${path}`;
+}
+
+function rebuild(): void {
+  const session = useCanvasSessionStore.getState();
+  const canvas = useCanvasStore.getState();
+  const { selection, files } = session;
+
+  if (selection.length === 0) {
+    canvas.clearCanvas();
+    return;
+  }
+
+  if (!session.allSelectedLoaded()) {
+    return;
+  }
+
+  if (selection.length === 1) {
+    const p = selection[0];
+    const content = files[p]?.content ?? "";
+    canvas.loadFromYAML(content, p, playbookIdFor(p));
+    return;
+  }
+
+  const playbooks = selection.map((p) => ({
+    content: files[p]?.content ?? "",
+    filename: p,
+    id: playbookIdFor(p),
+  }));
+  canvas.loadMultiplePlaybooks(playbooks);
+}
+
+let initialized = false;
+
+export function initCanvasRebuild(): void {
+  if (initialized) return;
+  initialized = true;
+
+  useCanvasSessionStore.subscribe(
+    (s) => s.selection,
+    () => rebuild(),
+  );
+
+  useCanvasSessionStore.subscribe(
+    (s) => s.files,
+    () => rebuild(),
+  );
+
+  useCanvasStore.subscribe(
+    (s) => s.viewMode,
+    () => rebuild(),
+  );
+
+  rebuild();
+}

--- a/a-station-react-app/src/stores/canvasSessionStore.ts
+++ b/a-station-react-app/src/stores/canvasSessionStore.ts
@@ -1,0 +1,231 @@
+import { create } from "zustand";
+import { subscribeWithSelector } from "zustand/middleware";
+import { toast } from "sonner";
+import { getFileContent } from "@/api/source-api";
+
+export type FileStatus = "loading" | "loaded" | "error";
+
+export interface CanvasFile {
+  path: string;
+  status: FileStatus;
+  content?: string;
+  error?: string;
+  abort?: AbortController;
+}
+
+export interface LoadContext {
+  workspaceId: string;
+  sourceId: string;
+}
+
+interface CanvasSessionStore {
+  files: Record<string, CanvasFile>;
+  selection: string[];
+  anchor: string | null;
+  focused: string | null;
+
+  replace: (paths: string[], ctx: LoadContext) => void;
+  toggle: (path: string, ctx: LoadContext) => void;
+  range: (paths: string[], focused: string, ctx: LoadContext) => void;
+  clear: () => void;
+
+  setFocused: (path: string | null, ctx: LoadContext) => void;
+
+  retry: (path: string, ctx: LoadContext) => void;
+
+  allSelectedLoaded: () => boolean;
+  loadingCount: () => number;
+  errorCount: () => number;
+  totalSelected: () => number;
+}
+
+// ─── Internal fetch / cancel helpers ───
+
+async function fetchOne(path: string, ctx: LoadContext): Promise<void> {
+  const abort = new AbortController();
+
+  useCanvasSessionStore.setState((s) => ({
+    files: {
+      ...s.files,
+      [path]: { path, status: "loading", abort },
+    },
+  }));
+
+  try {
+    const result = await getFileContent(ctx.workspaceId, ctx.sourceId, path);
+
+    const cur = useCanvasSessionStore.getState().files[path];
+    if (!cur || cur.abort !== abort) return;
+
+    if (result.success) {
+      useCanvasSessionStore.setState((s) => ({
+        files: {
+          ...s.files,
+          [path]: {
+            path,
+            status: "loaded",
+            content: result.data.content,
+          },
+        },
+      }));
+    } else {
+      const message =
+        result.error.message || result.error.detail || "Failed to load file";
+      useCanvasSessionStore.setState((s) => ({
+        files: {
+          ...s.files,
+          [path]: { path, status: "error", error: message },
+        },
+      }));
+      toast.error(`Failed to load ${path}`, {
+        description: message,
+        action: {
+          label: "Retry",
+          onClick: () => useCanvasSessionStore.getState().retry(path, ctx),
+        },
+      });
+    }
+  } catch (e) {
+    const cur = useCanvasSessionStore.getState().files[path];
+    if (!cur || cur.abort !== abort) return;
+    const message = e instanceof Error ? e.message : "Unknown error";
+    useCanvasSessionStore.setState((s) => ({
+      files: {
+        ...s.files,
+        [path]: { path, status: "error", error: message },
+      },
+    }));
+    toast.error(`Failed to load ${path}`, {
+      description: message,
+      action: {
+        label: "Retry",
+        onClick: () => useCanvasSessionStore.getState().retry(path, ctx),
+      },
+    });
+  }
+}
+
+function ensureLoaded(paths: string[], ctx: LoadContext): void {
+  const state = useCanvasSessionStore.getState();
+  for (const p of paths) {
+    const existing = state.files[p];
+    if (existing?.status === "loaded" || existing?.status === "loading") {
+      continue;
+    }
+    void fetchOne(p, ctx);
+  }
+}
+
+function cancelFor(paths: string[]): void {
+  const state = useCanvasSessionStore.getState();
+  let changed = false;
+  const next = { ...state.files };
+  for (const p of paths) {
+    const f = next[p];
+    if (f?.status === "loading" && f.abort) {
+      f.abort.abort();
+      delete next[p];
+      changed = true;
+    }
+  }
+  if (changed) {
+    useCanvasSessionStore.setState({ files: next });
+  }
+}
+
+// ─── Store ───
+
+export const useCanvasSessionStore = create<CanvasSessionStore>()(
+  subscribeWithSelector((set, get) => ({
+    files: {},
+    selection: [],
+    anchor: null,
+    focused: null,
+
+    replace: (paths, ctx) => {
+      const prev = get();
+      const removed = prev.selection.filter((p) => !paths.includes(p));
+      cancelFor(removed);
+
+      const last = paths[paths.length - 1] ?? null;
+      const keepFocused = prev.focused && paths.includes(prev.focused);
+      set({
+        selection: paths,
+        focused: keepFocused ? prev.focused : last,
+        anchor: last,
+      });
+
+      ensureLoaded(paths, ctx);
+    },
+
+    toggle: (path, ctx) => {
+      const prev = get();
+      if (prev.selection.includes(path)) {
+        cancelFor([path]);
+        const next = prev.selection.filter((p) => p !== path);
+        set({
+          selection: next,
+          focused: prev.focused === path ? (next[0] ?? null) : prev.focused,
+          anchor: path,
+        });
+      } else {
+        set({
+          selection: [...prev.selection, path],
+          focused: path,
+          anchor: path,
+        });
+        ensureLoaded([path], ctx);
+      }
+    },
+
+    range: (paths, focused, ctx) => {
+      const prev = get();
+      const removed = prev.selection.filter((p) => !paths.includes(p));
+      cancelFor(removed);
+      set({
+        selection: paths,
+        focused,
+      });
+      ensureLoaded(paths, ctx);
+    },
+
+    clear: () => {
+      cancelFor(get().selection);
+      set({
+        files: {},
+        selection: [],
+        focused: null,
+        anchor: null,
+      });
+    },
+
+    setFocused: (path, ctx) => {
+      set({ focused: path });
+      if (!path) return;
+      const existing = get().files[path];
+      if (existing?.status === "loaded") return;
+      void fetchOne(path, ctx);
+    },
+
+    retry: (path, ctx) => {
+      void fetchOne(path, ctx);
+    },
+
+    allSelectedLoaded: () => {
+      const { files, selection } = get();
+      return selection.every((p) => files[p]?.status === "loaded");
+    },
+
+    loadingCount: () => {
+      const { files, selection } = get();
+      return selection.filter((p) => files[p]?.status === "loading").length;
+    },
+
+    errorCount: () => {
+      const { files, selection } = get();
+      return selection.filter((p) => files[p]?.status === "error").length;
+    },
+
+    totalSelected: () => get().selection.length,
+  })),
+);

--- a/a-station-react-app/src/stores/canvasStore.ts
+++ b/a-station-react-app/src/stores/canvasStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { persist, subscribeWithSelector } from "zustand/middleware";
+import { toast } from "sonner";
 import {
   type Node,
   type Edge,
@@ -470,6 +471,7 @@ function buildGroupSummary(result: ParseResult, headNodeId: string): string {
 // ─── Store ───
 
 export const useCanvasStore = create<CanvasStore>()(
+  subscribeWithSelector(
   persist(
     (set, get) => ({
       nodes: [],
@@ -510,7 +512,9 @@ export const useCanvasStore = create<CanvasStore>()(
         );
 
         if (!result.success) {
-          console.error("Failed to parse YAML:", result.error);
+          toast.error(`Failed to parse ${playbookFile}`, {
+            description: result.error ?? "Unknown parser error",
+          });
           set({ nodes: [], edges: [] });
           return;
         }
@@ -527,9 +531,24 @@ export const useCanvasStore = create<CanvasStore>()(
         const result = playbookParser.parseMultiple(playbooks);
 
         if (!result.success) {
-          console.error("Failed to parse playbooks:", result.error);
+          toast.error("Failed to parse playbooks", {
+            description: result.error ?? "Unknown parser error",
+          });
           set({ nodes: [], edges: [] });
           return;
+        }
+
+        if (result.partialErrors && result.partialErrors.length > 0) {
+          const n = result.partialErrors.length;
+          const first = result.partialErrors[0];
+          toast.warning(
+            `${n} playbook${n === 1 ? "" : "s"} failed to parse`,
+            {
+              description: `${first.filename}: ${first.error}${
+                n > 1 ? ` (+${n - 1} more)` : ""
+              }`,
+            },
+          );
         }
 
         const layout =
@@ -605,12 +624,8 @@ export const useCanvasStore = create<CanvasStore>()(
       name: "canvas-storage",
       partialize: (state) => ({
         viewMode: state.viewMode,
-        nodes: state.nodes.map((node) => ({
-          ...node,
-          data: { ...node.data, state: "idle" },
-        })),
-        edges: state.edges,
       }),
     },
+  ),
   ),
 );

--- a/a-station-react-app/src/stores/canvasStore.ts
+++ b/a-station-react-app/src/stores/canvasStore.ts
@@ -333,6 +333,122 @@ function buildGroupedLayout(result: ParseResult): {
   return { nodes, edges };
 }
 
+// Approximate rendered size of each node type — used for frame bbox math.
+function nodeSize(type: string): { w: number; h: number } {
+  switch (type) {
+    case "headNode":
+      return { w: 380, h: 160 };
+    case "taskGroup":
+      return { w: 280, h: 60 };
+    case "simpleTask":
+    case "roleNode":
+      return { w: 280, h: 100 };
+    default:
+      return { w: 280, h: 100 };
+  }
+}
+
+// Walks the laid-out nodes, groups them by playbookId, and prepends
+// a playbookFrame node sized to the bounding box of each group. Frame
+// nodes have zIndex -1 so real nodes sit on top and remain clickable.
+function withPlaybookFrames(
+  layoutNodes: Node<AnyNodeData>[],
+): Node<AnyNodeData>[] {
+  type Box = {
+    file: string;
+    minX: number;
+    minY: number;
+    maxX: number;
+    maxY: number;
+  };
+  const boxes = new Map<string, Box>();
+
+  // First pass: build a map of headNodeId → playbookId so taskGroup nodes
+  // (which only carry parentHeadNodeId) can be attributed correctly.
+  const headToPlaybook = new Map<string, { id: string; file: string }>();
+  for (const n of layoutNodes) {
+    if (n.data.type === "headNode") {
+      headToPlaybook.set(n.id, {
+        id: n.data.playbookId,
+        file: n.data.playbookFile,
+      });
+    }
+  }
+
+  for (const n of layoutNodes) {
+    let pid: string | undefined;
+    let pfile: string | undefined;
+
+    if (
+      n.data.type === "headNode" ||
+      n.data.type === "simpleTask" ||
+      n.data.type === "roleNode"
+    ) {
+      pid = n.data.playbookId;
+      pfile = n.data.playbookFile;
+    } else if (n.data.type === "taskGroup") {
+      const parent = headToPlaybook.get(n.data.parentHeadNodeId);
+      if (parent) {
+        pid = parent.id;
+        pfile = parent.file;
+      }
+    }
+
+    if (!pid) continue;
+
+    const { w, h } = nodeSize(n.data.type);
+    const x1 = n.position.x;
+    const y1 = n.position.y;
+    const x2 = x1 + w;
+    const y2 = y1 + h;
+
+    const existing = boxes.get(pid);
+    if (existing) {
+      existing.minX = Math.min(existing.minX, x1);
+      existing.minY = Math.min(existing.minY, y1);
+      existing.maxX = Math.max(existing.maxX, x2);
+      existing.maxY = Math.max(existing.maxY, y2);
+    } else {
+      boxes.set(pid, {
+        file: pfile ?? pid,
+        minX: x1,
+        minY: y1,
+        maxX: x2,
+        maxY: y2,
+      });
+    }
+  }
+
+  const PAD = 36;
+  const TITLE_PAD = 24;
+
+  const frames: Node<AnyNodeData>[] = [];
+  for (const [pid, box] of boxes) {
+    const x = box.minX - PAD;
+    const y = box.minY - PAD - TITLE_PAD;
+    const width = box.maxX - box.minX + PAD * 2;
+    const height = box.maxY - box.minY + PAD * 2 + TITLE_PAD;
+    frames.push({
+      id: `frame-${pid}`,
+      type: "playbookFrame",
+      position: { x, y },
+      data: {
+        type: "playbookFrame",
+        playbookId: pid,
+        playbookFile: box.file,
+        width,
+        height,
+        state: "idle",
+      },
+      draggable: false,
+      selectable: false,
+      zIndex: -1,
+    });
+  }
+
+  return [...frames, ...layoutNodes];
+}
+
 function buildGroupSummary(result: ParseResult, headNodeId: string): string {
   const groups = result.taskGroups.filter(
     (g) => g.parentHeadNodeId === headNodeId,
@@ -404,7 +520,7 @@ export const useCanvasStore = create<CanvasStore>()(
             ? buildGroupedLayout(result)
             : buildFlatLayout(result);
 
-        set(layout);
+        set({ nodes: withPlaybookFrames(layout.nodes), edges: layout.edges });
       },
 
       loadMultiplePlaybooks: (playbooks) => {
@@ -421,7 +537,7 @@ export const useCanvasStore = create<CanvasStore>()(
             ? buildGroupedLayout(result)
             : buildFlatLayout(result);
 
-        set(layout);
+        set({ nodes: withPlaybookFrames(layout.nodes), edges: layout.edges });
       },
 
       toggleHeadNodeExpansion: (headNodeId) => {

--- a/a-station-react-app/src/stores/sourceStore.ts
+++ b/a-station-react-app/src/stores/sourceStore.ts
@@ -18,8 +18,16 @@ interface SourceStore {
   sources: ProjectSource[];
   activeSourceId: string | null;
   fileTree: FileTreeNode | null;
-  selectedFilePath: string | null;
-  selectedFileContent: string | null;
+
+  // Multi-file selection: files loaded onto the canvas (YAML only)
+  selectedFilePaths: string[];
+  // Cache of fetched file contents keyed by path
+  fileContents: Record<string, string>;
+  // The single file shown in the YAML preview pane (may be non-YAML)
+  focusedFilePath: string | null;
+  // Anchor for shift-range selection (last non-shift click)
+  selectionAnchor: string | null;
+
   loading: boolean;
   fileLoading: boolean;
   syncLoading: boolean;
@@ -51,10 +59,17 @@ interface SourceStore {
     sourceId: string,
     token: string,
   ) => Promise<void>;
-  selectFile: (
+
+  setSelection: (
+    paths: string[],
+    focused: string | null,
+    anchor: string | null,
+  ) => void;
+  setFocusedFile: (path: string | null) => void;
+  loadFileContents: (
     workspaceId: string,
     sourceId: string,
-    path: string,
+    paths: string[],
     token: string,
   ) => Promise<void>;
   clearSelection: () => void;
@@ -62,14 +77,20 @@ interface SourceStore {
   getActiveSource: () => ProjectSource | null;
 }
 
+const emptySelection = {
+  selectedFilePaths: [] as string[],
+  fileContents: {} as Record<string, string>,
+  focusedFilePath: null as string | null,
+  selectionAnchor: null as string | null,
+};
+
 export const useSourceStore = create<SourceStore>()(
   persist(
     (set, get) => ({
       sources: [],
       activeSourceId: null,
       fileTree: null,
-      selectedFilePath: null,
-      selectedFileContent: null,
+      ...emptySelection,
       loading: false,
       fileLoading: false,
       syncLoading: false,
@@ -112,8 +133,7 @@ export const useSourceStore = create<SourceStore>()(
         set({
           activeSourceId: sourceId,
           fileTree: null,
-          selectedFilePath: null,
-          selectedFileContent: null,
+          ...emptySelection,
         });
         await get().fetchFileTree(workspaceId, sourceId, token);
       },
@@ -159,8 +179,7 @@ export const useSourceStore = create<SourceStore>()(
                 set({
                   activeSourceId: null,
                   fileTree: null,
-                  selectedFilePath: null,
-                  selectedFileContent: null,
+                  ...emptySelection,
                 });
               }
             }
@@ -224,40 +243,54 @@ export const useSourceStore = create<SourceStore>()(
         }
       },
 
-      selectFile: async (workspaceId, sourceId, path, token) => {
-        set({ fileLoading: true, selectedFilePath: path, selectedFileContent: null });
+      setSelection: (paths, focused, anchor) => {
+        set({
+          selectedFilePaths: paths,
+          focusedFilePath: focused,
+          selectionAnchor: anchor,
+        });
+      },
+
+      setFocusedFile: (path) => {
+        set({ focusedFilePath: path });
+      },
+
+      loadFileContents: async (workspaceId, sourceId, paths, token) => {
+        const state = get();
+        const missing = paths.filter(
+          (p) => state.fileContents[p] === undefined,
+        );
+        if (missing.length === 0) return;
+
+        set({ fileLoading: true });
 
         try {
-          const result = await getFileContent(
-            workspaceId,
-            sourceId,
-            path,
-            token,
+          const results = await Promise.all(
+            missing.map((p) =>
+              getFileContent(workspaceId, sourceId, p, token).then((r) => ({
+                p,
+                r,
+              })),
+            ),
           );
 
-          if (result.success) {
-            set({
-              selectedFileContent: result.data.content,
-              fileLoading: false,
-            });
-          } else {
-            set({
-              selectedFileContent: null,
-              fileLoading: false,
-              error: "Failed to load file",
-            });
+          const next = { ...get().fileContents };
+          for (const { p, r } of results) {
+            if (r.success) {
+              next[p] = r.data.content;
+            }
           }
+          set({ fileContents: next, fileLoading: false });
         } catch {
           set({
-            selectedFileContent: null,
             fileLoading: false,
-            error: "An unexpected error occurred",
+            error: "Failed to load file contents",
           });
         }
       },
 
       clearSelection: () => {
-        set({ selectedFilePath: null, selectedFileContent: null });
+        set({ ...emptySelection });
       },
 
       clearAll: () => {
@@ -265,8 +298,7 @@ export const useSourceStore = create<SourceStore>()(
           sources: [],
           activeSourceId: null,
           fileTree: null,
-          selectedFilePath: null,
-          selectedFileContent: null,
+          ...emptySelection,
           loading: false,
           fileLoading: false,
           syncLoading: false,

--- a/a-station-react-app/src/stores/sourceStore.ts
+++ b/a-station-react-app/src/stores/sourceStore.ts
@@ -33,31 +33,26 @@ interface SourceStore {
   syncLoading: boolean;
   error: string | null;
 
-  fetchSources: (workspaceId: string, token: string) => Promise<void>;
+  fetchSources: (workspaceId: string) => Promise<void>;
   setActiveSource: (
     sourceId: string,
     workspaceId: string,
-    token: string,
   ) => Promise<void>;
   addSource: (
     workspaceId: string,
     data: ProjectSourceCreate,
-    token: string,
   ) => Promise<{ success: boolean; error?: string }>;
   removeSource: (
     workspaceId: string,
     sourceId: string,
-    token: string,
   ) => Promise<{ success: boolean; error?: string }>;
   syncSource: (
     workspaceId: string,
     sourceId: string,
-    token: string,
   ) => Promise<{ success: boolean; error?: string }>;
   fetchFileTree: (
     workspaceId: string,
     sourceId: string,
-    token: string,
   ) => Promise<void>;
 
   setSelection: (
@@ -70,7 +65,6 @@ interface SourceStore {
     workspaceId: string,
     sourceId: string,
     paths: string[],
-    token: string,
   ) => Promise<void>;
   clearSelection: () => void;
   clearAll: () => void;
@@ -96,16 +90,16 @@ export const useSourceStore = create<SourceStore>()(
       syncLoading: false,
       error: null,
 
-      fetchSources: async (workspaceId, token) => {
-        if (!token || !workspaceId) {
-          set({ error: "Missing auth token or workspace ID" });
+      fetchSources: async (workspaceId) => {
+        if (!workspaceId) {
+          set({ error: "Missing workspace ID" });
           return;
         }
 
         set({ loading: true, error: null });
 
         try {
-          const result = await getSources(workspaceId, token);
+          const result = await getSources(workspaceId);
 
           if (result.success) {
             set({ sources: result.data, loading: false });
@@ -116,10 +110,10 @@ export const useSourceStore = create<SourceStore>()(
 
             if (stillExists) {
               // Persisted source is valid — just load its file tree
-              await get().fetchFileTree(workspaceId, persisted!, token);
+              await get().fetchFileTree(workspaceId, persisted!);
             } else if (result.data.length > 0) {
               // No valid persisted source — pick the first one
-              get().setActiveSource(result.data[0].id, workspaceId, token);
+              get().setActiveSource(result.data[0].id, workspaceId);
             }
           } else {
             set({ error: "Failed to fetch sources", loading: false });
@@ -129,18 +123,18 @@ export const useSourceStore = create<SourceStore>()(
         }
       },
 
-      setActiveSource: async (sourceId, workspaceId, token) => {
+      setActiveSource: async (sourceId, workspaceId) => {
         set({
           activeSourceId: sourceId,
           fileTree: null,
           ...emptySelection,
         });
-        await get().fetchFileTree(workspaceId, sourceId, token);
+        await get().fetchFileTree(workspaceId, sourceId);
       },
 
-      addSource: async (workspaceId, data, token) => {
+      addSource: async (workspaceId, data) => {
         try {
-          const result = await createSource(workspaceId, data, token);
+          const result = await createSource(workspaceId, data);
 
           if (result.success) {
             const state = get();
@@ -149,7 +143,7 @@ export const useSourceStore = create<SourceStore>()(
 
             // If this is the first source, auto-activate it
             if (!state.activeSourceId) {
-              get().setActiveSource(result.data.id, workspaceId, token);
+              get().setActiveSource(result.data.id, workspaceId);
             }
             return { success: true };
           } else {
@@ -163,9 +157,9 @@ export const useSourceStore = create<SourceStore>()(
         }
       },
 
-      removeSource: async (workspaceId, sourceId, token) => {
+      removeSource: async (workspaceId, sourceId) => {
         try {
-          const result = await deleteSource(workspaceId, sourceId, token);
+          const result = await deleteSource(workspaceId, sourceId);
 
           if (result.success) {
             const state = get();
@@ -174,7 +168,7 @@ export const useSourceStore = create<SourceStore>()(
 
             if (state.activeSourceId === sourceId) {
               if (updated.length > 0) {
-                get().setActiveSource(updated[0].id, workspaceId, token);
+                get().setActiveSource(updated[0].id, workspaceId);
               } else {
                 set({
                   activeSourceId: null,
@@ -195,11 +189,11 @@ export const useSourceStore = create<SourceStore>()(
         }
       },
 
-      syncSource: async (workspaceId, sourceId, token) => {
+      syncSource: async (workspaceId, sourceId) => {
         set({ syncLoading: true });
 
         try {
-          const result = await syncSource(workspaceId, sourceId, token);
+          const result = await syncSource(workspaceId, sourceId);
 
           if (result.success) {
             set({
@@ -211,7 +205,7 @@ export const useSourceStore = create<SourceStore>()(
 
             // Refresh file tree if this is the active source
             if (get().activeSourceId === sourceId) {
-              await get().fetchFileTree(workspaceId, sourceId, token);
+              await get().fetchFileTree(workspaceId, sourceId);
             }
             return { success: true };
           } else {
@@ -227,11 +221,11 @@ export const useSourceStore = create<SourceStore>()(
         }
       },
 
-      fetchFileTree: async (workspaceId, sourceId, token) => {
+      fetchFileTree: async (workspaceId, sourceId) => {
         set({ loading: true, error: null });
 
         try {
-          const result = await getFileTree(workspaceId, sourceId, token);
+          const result = await getFileTree(workspaceId, sourceId);
 
           if (result.success) {
             set({ fileTree: result.data, loading: false });
@@ -255,7 +249,7 @@ export const useSourceStore = create<SourceStore>()(
         set({ focusedFilePath: path });
       },
 
-      loadFileContents: async (workspaceId, sourceId, paths, token) => {
+      loadFileContents: async (workspaceId, sourceId, paths) => {
         const state = get();
         const missing = paths.filter(
           (p) => state.fileContents[p] === undefined,
@@ -267,7 +261,7 @@ export const useSourceStore = create<SourceStore>()(
         try {
           const results = await Promise.all(
             missing.map((p) =>
-              getFileContent(workspaceId, sourceId, p, token).then((r) => ({
+              getFileContent(workspaceId, sourceId, p).then((r) => ({
                 p,
                 r,
               })),

--- a/a-station-react-app/src/stores/sourceStore.ts
+++ b/a-station-react-app/src/stores/sourceStore.ts
@@ -11,33 +11,20 @@ import {
   deleteSource,
   syncSource,
   getFileTree,
-  getFileContent,
 } from "@/api/source-api";
+import { useCanvasSessionStore } from "./canvasSessionStore";
 
 interface SourceStore {
   sources: ProjectSource[];
   activeSourceId: string | null;
   fileTree: FileTreeNode | null;
 
-  // Multi-file selection: files loaded onto the canvas (YAML only)
-  selectedFilePaths: string[];
-  // Cache of fetched file contents keyed by path
-  fileContents: Record<string, string>;
-  // The single file shown in the YAML preview pane (may be non-YAML)
-  focusedFilePath: string | null;
-  // Anchor for shift-range selection (last non-shift click)
-  selectionAnchor: string | null;
-
   loading: boolean;
-  fileLoading: boolean;
   syncLoading: boolean;
   error: string | null;
 
   fetchSources: (workspaceId: string) => Promise<void>;
-  setActiveSource: (
-    sourceId: string,
-    workspaceId: string,
-  ) => Promise<void>;
+  setActiveSource: (sourceId: string, workspaceId: string) => Promise<void>;
   addSource: (
     workspaceId: string,
     data: ProjectSourceCreate,
@@ -50,33 +37,10 @@ interface SourceStore {
     workspaceId: string,
     sourceId: string,
   ) => Promise<{ success: boolean; error?: string }>;
-  fetchFileTree: (
-    workspaceId: string,
-    sourceId: string,
-  ) => Promise<void>;
-
-  setSelection: (
-    paths: string[],
-    focused: string | null,
-    anchor: string | null,
-  ) => void;
-  setFocusedFile: (path: string | null) => void;
-  loadFileContents: (
-    workspaceId: string,
-    sourceId: string,
-    paths: string[],
-  ) => Promise<void>;
-  clearSelection: () => void;
+  fetchFileTree: (workspaceId: string, sourceId: string) => Promise<void>;
   clearAll: () => void;
   getActiveSource: () => ProjectSource | null;
 }
-
-const emptySelection = {
-  selectedFilePaths: [] as string[],
-  fileContents: {} as Record<string, string>,
-  focusedFilePath: null as string | null,
-  selectionAnchor: null as string | null,
-};
 
 export const useSourceStore = create<SourceStore>()(
   persist(
@@ -84,9 +48,7 @@ export const useSourceStore = create<SourceStore>()(
       sources: [],
       activeSourceId: null,
       fileTree: null,
-      ...emptySelection,
       loading: false,
-      fileLoading: false,
       syncLoading: false,
       error: null,
 
@@ -106,13 +68,12 @@ export const useSourceStore = create<SourceStore>()(
 
             const state = get();
             const persisted = state.activeSourceId;
-            const stillExists = persisted && result.data.some((s) => s.id === persisted);
+            const stillExists =
+              persisted && result.data.some((s) => s.id === persisted);
 
             if (stillExists) {
-              // Persisted source is valid — just load its file tree
               await get().fetchFileTree(workspaceId, persisted!);
             } else if (result.data.length > 0) {
-              // No valid persisted source — pick the first one
               get().setActiveSource(result.data[0].id, workspaceId);
             }
           } else {
@@ -124,10 +85,10 @@ export const useSourceStore = create<SourceStore>()(
       },
 
       setActiveSource: async (sourceId, workspaceId) => {
+        useCanvasSessionStore.getState().clear();
         set({
           activeSourceId: sourceId,
           fileTree: null,
-          ...emptySelection,
         });
         await get().fetchFileTree(workspaceId, sourceId);
       },
@@ -141,7 +102,6 @@ export const useSourceStore = create<SourceStore>()(
             const updated = [...state.sources, result.data];
             set({ sources: updated });
 
-            // If this is the first source, auto-activate it
             if (!state.activeSourceId) {
               get().setActiveSource(result.data.id, workspaceId);
             }
@@ -149,7 +109,10 @@ export const useSourceStore = create<SourceStore>()(
           } else {
             return {
               success: false,
-              error: result.error?.message || result.error?.detail || "Failed to add source",
+              error:
+                result.error?.message ||
+                result.error?.detail ||
+                "Failed to add source",
             };
           }
         } catch {
@@ -170,10 +133,10 @@ export const useSourceStore = create<SourceStore>()(
               if (updated.length > 0) {
                 get().setActiveSource(updated[0].id, workspaceId);
               } else {
+                useCanvasSessionStore.getState().clear();
                 set({
                   activeSourceId: null,
                   fileTree: null,
-                  ...emptySelection,
                 });
               }
             }
@@ -181,7 +144,10 @@ export const useSourceStore = create<SourceStore>()(
           } else {
             return {
               success: false,
-              error: result.error?.message || result.error?.detail || "Failed to remove source",
+              error:
+                result.error?.message ||
+                result.error?.detail ||
+                "Failed to remove source",
             };
           }
         } catch {
@@ -203,8 +169,8 @@ export const useSourceStore = create<SourceStore>()(
               syncLoading: false,
             });
 
-            // Refresh file tree if this is the active source
             if (get().activeSourceId === sourceId) {
+              useCanvasSessionStore.getState().clear();
               await get().fetchFileTree(workspaceId, sourceId);
             }
             return { success: true };
@@ -212,7 +178,8 @@ export const useSourceStore = create<SourceStore>()(
             set({ syncLoading: false });
             return {
               success: false,
-              error: result.error?.message || result.error?.detail || "Sync failed",
+              error:
+                result.error?.message || result.error?.detail || "Sync failed",
             };
           }
         } catch {
@@ -237,64 +204,13 @@ export const useSourceStore = create<SourceStore>()(
         }
       },
 
-      setSelection: (paths, focused, anchor) => {
-        set({
-          selectedFilePaths: paths,
-          focusedFilePath: focused,
-          selectionAnchor: anchor,
-        });
-      },
-
-      setFocusedFile: (path) => {
-        set({ focusedFilePath: path });
-      },
-
-      loadFileContents: async (workspaceId, sourceId, paths) => {
-        const state = get();
-        const missing = paths.filter(
-          (p) => state.fileContents[p] === undefined,
-        );
-        if (missing.length === 0) return;
-
-        set({ fileLoading: true });
-
-        try {
-          const results = await Promise.all(
-            missing.map((p) =>
-              getFileContent(workspaceId, sourceId, p).then((r) => ({
-                p,
-                r,
-              })),
-            ),
-          );
-
-          const next = { ...get().fileContents };
-          for (const { p, r } of results) {
-            if (r.success) {
-              next[p] = r.data.content;
-            }
-          }
-          set({ fileContents: next, fileLoading: false });
-        } catch {
-          set({
-            fileLoading: false,
-            error: "Failed to load file contents",
-          });
-        }
-      },
-
-      clearSelection: () => {
-        set({ ...emptySelection });
-      },
-
       clearAll: () => {
+        useCanvasSessionStore.getState().clear();
         set({
           sources: [],
           activeSourceId: null,
           fileTree: null,
-          ...emptySelection,
           loading: false,
-          fileLoading: false,
           syncLoading: false,
           error: null,
         });

--- a/a-station-react-app/src/stores/workspaceStore.ts
+++ b/a-station-react-app/src/stores/workspaceStore.ts
@@ -11,7 +11,7 @@ interface WorkspaceStore {
   loading: boolean;
   error: string | null;
 
-  fetchWorkspaces: (authToken: string) => Promise<void>; // CHANGED
+  fetchWorkspaces: () => Promise<void>;
   setSelectedWorkspace: (workspace: Workspace) => void;
   clearSelectedWorkspace: () => void;
 }
@@ -24,16 +24,11 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
       loading: false,
       error: null,
 
-      fetchWorkspaces: async (authToken: string) => {
-        if (!authToken) {
-          set({ error: "No auth token available" });
-          return;
-        }
-
+      fetchWorkspaces: async () => {
         set({ loading: true, error: null });
 
         try {
-          const result = await getWorkspaces(authToken);
+          const result = await getWorkspaces();
 
           if (result.success) {
             set({

--- a/a-station-react-app/src/types/nodes.ts
+++ b/a-station-react-app/src/types/nodes.ts
@@ -131,8 +131,18 @@ export interface RoleNodeData {
   type: "roleNode";
 }
 
+export interface PlaybookFrameNodeData {
+  type: "playbookFrame";
+  playbookId: string;
+  playbookFile: string;
+  width: number;
+  height: number;
+  state: ExecutionState;
+}
+
 export type AnyNodeData =
   | TaskNodeData
   | HeadNodeData
   | TaskGroupNodeData
-  | RoleNodeData;
+  | RoleNodeData
+  | PlaybookFrameNodeData;


### PR DESCRIPTION
## Summary

Three independent changes bundled on the `multi-playbook-canvas` branch:

### 1. Multi-playbook canvas (`12f0566`)
The canvas can now render multiple playbooks at once instead of only the single selected file.

- `sourceStore` tracks `selectedFilePaths` + `fileContents` map (replacing the single `selectedFilePath` / `selectedFileContent`) plus a `focusedFilePath` for the YAML pane.
- `canvasStore` gains `loadMultiplePlaybooks`, which parses each YAML and lays them out side-by-side.
- New `PlaybookFrameNode` draws a dashed container behind each playbook's nodes so multiple playbooks read as distinct units on the canvas; added to `nodeTypes`.
- Clicking any node inside a frame sets that playbook as the focused one — drives which YAML the right-hand pane shows and which playbook the Execute button runs.
- Execute is disabled unless the focused path is actually a YAML still on the canvas (`runnablePath` guard).
- `FileTree` updated for multi-select; `YamlTab` reads focused content.

### 2. Wire dead buttons + A-Station Cloud CTA + resizable panels (`8435f19`)
- Adds `react-resizable-panels` and a `ui/resizable.tsx` wrapper; `Dashboard` now uses resizable panel groups for the file tree / canvas / YAML layout.
- New `ComingSoonDialog` modal wired to previously dead buttons in `DashboardNavigation` (Project Browser, Inventory Manager, Run History) and `DashboardTopBar` (Settings, Account).
- New `ACloudDialog` replaces the old \"Upgrade\" button with an A-Station Cloud CTA in the top bar.
- `SecondaryToolbar`, `WorkspaceSelect`, `CreateWorkspace`, `AddSource` cleanups along the way.

### 3. `apiFetch` wrapper (`8a51883`)
New `src/api/client.ts` exporting `apiFetch`:

- Attaches `Authorization: Bearer <token>` from `authStore` and `credentials: \"include\"`.
- On 401, calls `authStore.refresh()` once (concurrent calls coalesce via `refreshInFlight`), then retries the original request with the new token.
- If refresh fails, clears auth state and hard-redirects to `/login`.
- `job-api`, `source-api`, `workspace-api` all migrated to `apiFetch` and no longer take an `accessToken` parameter. `useJobExecution` updated accordingly.

## Stats
27 files changed, +1097 / -398.

## Test plan
- [ ] Select multiple `.yml` / `.yaml` files in the file tree — each renders inside its own frame on the canvas
- [ ] Click a node inside a frame — YAML pane switches to that playbook, Execute button targets it
- [ ] Execute is disabled when no playbook node is focused or when the focused file isn't on the canvas
- [ ] Trigger a 401 (e.g. let the access token expire) — request transparently refreshes and retries; concurrent requests only refresh once
- [ ] Refresh failure redirects to `/login` and clears auth state
- [ ] Dashboard panels resize and persist expected layout
- [ ] Previously dead top-bar / nav buttons now open Coming Soon dialogs; Cloud button opens A-Station Cloud dialog